### PR TITLE
Agents own the pets, worktrees become dens

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,26 @@ echo "clippy=$(cargo clippy --message-format=short 2>&1 | grep -c '^warning')"
 Signals are user configuration rather than part of the tool, so there is nothing
 to submit unless you want one documented in the README as an example.
 
+## Hook fixtures
+
+`cmd/pets/testdata/` holds payloads captured from a real session, not written by
+hand. That distinction is the point: a hand-written fixture encodes what its
+author believed the harness sends, so a test built on one agrees with the
+author's mistake. This project shipped that exact bug once, and every test passed
+while the code read escaped JSON source instead of text.
+
+To refresh one, point the hook or status line at a script that tees stdin before
+calling `pets`, then **sanitise it before committing**. A real payload carries
+your username in several absolute paths, your repository owner, the session name
+and `cost.total_cost_usd`. Replace them with the `example/demo` and
+`/home/user/...` placeholders already used in the existing fixtures, and keep
+the worktree path exactly as it is: the tests rewrite that one field and nothing
+else, so the shape stays as the harness sent it.
+
+Assert what the hook *wrote*, not what it returned. Its product is a cache entry
+with an expiry that a later render reads, so a function can decode perfectly and
+still record the wrong verdict.
+
 ## Working on the code
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 </p>
 
 <p align="center">
-  <strong>A creature for every git worktree, living in your coding agent's status line.</strong>
+  <strong>A creature for every agent, in a den for every git worktree.</strong>
 </p>
 
 <p align="center">
-  Its species comes from the branch name, and its mood tracks how tidy that branch is.
   Most terminal pets belong to <i>you</i>: one creature, nurtured over time. This one belongs
-  to a <b>worktree</b>. Six worktrees means six creatures alive at once, each recognisable at
-  a glance, so you always know which session you are looking at and which one is in trouble.
+  to an <b>agent</b>. Every worktree is a den with a name, every agent working in it gets its
+  own creature, and its mood tracks how tidy that worktree is. Six agents means six creatures
+  alive at once, each recognisable at a glance, so you always know which session you are
+  looking at and which one is in trouble.
 </p>
 
 <div align="center">
@@ -103,6 +104,7 @@ run something else and it works, or does not, please open an issue.
 
 | Glyph | Meaning |
 |---|---|
+| `@ DXB` | the den: which worktree, as a flight code |
 | `•ᴗ•` `•_•` `¬_¬` `>_<` `@_@` `x_x` | mood, five hearts down to zero |
 | `7△` | 7 uncommitted files |
 | `3↑` | 3 unpushed commits |
@@ -122,20 +124,23 @@ you already fixed.
 ## Seeing every worktree at once
 
 ```
-  pets party                                  6 alive
+  pets party                              4 dens · 3 agents
 
-  /x_x\     cat  ✦     spike/wasm-build     ♡♡♡♡♡  22△ 9↑ ✗
-  <@_@>     moth ✦     refactor/auth-guard  ♥♡♡♡♡  41△ 13↑
-  \(¬_¬)/   crow ✦✦✦   docs/api-reference   ♥♥♥♡♡  1△ 1↑
-  o[¬_¬]o   seal ✦✦✦   fix/session-leak     ♥♥♥♡♡  2△ 1↑
-  {•_•}     fox  ✦     chore/bump-deps      ♥♥♥♥♡  3↑
-  <•_•>     moth ✦     feat/checkout-flow   ♥♥♥♥♡  1↑
+  @PAR (•_•)     otter ✦     refactor/auth-guard  ♥♥♥♥♡  3△
+       (•_•)     otter     fix the flaky auth test               just now
+       /•_•\     cat       audit the session middleware          just now
+  @SYD -[•_•]-   carp  ✦     spike/wasm-build     ♥♥♥♥♡  9△
+       -[•_•]-   carp      port the wasm build to esbuild        just now
+  @MEX {•ᴗ•}     fox   ✦     chore/bump-deps      ♥♥♥♥♥
+  @IST \(•ᴗ•)/   crow  ✦✦✦   docs/api-reference   ♥♥♥♥♥
 
-  worst: cat · uncommitted, unpushed, tests
+  worst: otter · uncommitted
 ```
 
-Worst first, so whatever needs attention is at the top. Long lists are trimmed;
-`pets party --all` shows everything.
+Worst first, so whatever needs attention is at the top. Dens with agents in them
+list who is there, with the session's own name, so two agents sharing a worktree
+are two creatures rather than one. Empty dens still show a creature. Long lists
+are trimmed; `pets party --all` shows everything.
 
 ## Collecting them
 
@@ -157,10 +162,10 @@ what keeps two branches on the same creature telling apart.
 Shiny is a separate 1-in-128 roll, so even a common can be a find. `pets den`
 shows your collection.
 
-The same branch name always summons the same creature, on any machine, so a
-silhouette is a reliable way to recognise a session. The only way to roll a new
-one is to open a new worktree, and a creature joins your den once that worktree
-has a commit.
+A creature belongs to an agent and lasts as long as that session does, so
+starting a session is a fresh roll. Dens are the stable half: the same repo and
+worktree resolve to the same city on any machine, with nothing stored, and a den
+remembers every agent that has worked in it even after they have moved on.
 
 ## Commands
 

--- a/cmd/pets/collection.go
+++ b/cmd/pets/collection.go
@@ -57,11 +57,18 @@ func partyCommand(args []string) {
 		}
 		tests := state.ReadTests(cacheDir, repo.Key(), now)
 		denKey := identity.DenKey(repo.Project(), repo.Worktree())
+		// A den always shows a creature, but it belongs to whoever is working
+		// there when anyone is. Only an empty den falls back to the branch.
+		residents := byDen[denKey]
+		petKey := repo.Branch
+		if representative, occupied := agents.Representative(residents, now); occupied {
+			petKey = representative.Session
+		}
 		views = append(views, render.View{
-			Pet:       identity.For(repo.Branch),
+			Pet:       identity.For(petKey),
 			Place:     identity.PlaceFor(repo.Project(), repo.Worktree()),
 			Den:       denKey,
-			Residents: byDen[denKey],
+			Residents: residents,
 			Branch:    repo.Branch,
 			Root:      repo.Root,
 			State:     current,

--- a/cmd/pets/collection.go
+++ b/cmd/pets/collection.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/TevvvB/parallel-harness-pets/internal/agents"
 	"github.com/TevvvB/parallel-harness-pets/internal/config"
 	"github.com/TevvvB/parallel-harness-pets/internal/den"
 	"github.com/TevvvB/parallel-harness-pets/internal/gitrepo"
@@ -39,6 +40,12 @@ func partyCommand(args []string) {
 	cacheDir := config.StateDir()
 	now := time.Now()
 
+	// Read the register once and group, rather than re-scanning it per worktree.
+	byDen := map[string][]agents.Record{}
+	for _, record := range agents.All(cacheDir, now) {
+		byDen[record.Den] = append(byDen[record.Den], record)
+	}
+
 	var views []render.View
 	for _, current := range state.All(cacheDir) {
 		repo, found := gitrepo.Locate(current.Root)
@@ -49,14 +56,18 @@ func partyCommand(args []string) {
 			refreshInBackground(repo.Root)
 		}
 		tests := state.ReadTests(cacheDir, repo.Key(), now)
+		denKey := identity.DenKey(repo.Project(), repo.Worktree())
 		views = append(views, render.View{
-			Pet:      identity.For(repo.Branch),
-			Branch:   repo.Branch,
-			Root:     repo.Root,
-			State:    current,
-			Tests:    tests,
-			Score:    score.Of(current, tests, settings),
-			HasState: true,
+			Pet:       identity.For(repo.Branch),
+			Place:     identity.PlaceFor(repo.Project(), repo.Worktree()),
+			Den:       denKey,
+			Residents: byDen[denKey],
+			Branch:    repo.Branch,
+			Root:      repo.Root,
+			State:     current,
+			Tests:     tests,
+			Score:     score.Of(current, tests, settings),
+			HasState:  true,
 		})
 	}
 	showAll := false
@@ -65,7 +76,7 @@ func partyCommand(args []string) {
 			showAll = true
 		}
 	}
-	fmt.Print(render.Party(views, settings, showAll))
+	fmt.Print(render.Party(views, settings, showAll, now))
 	fmt.Print(updateNotice(settings))
 }
 

--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/TevvvB/parallel-harness-pets/internal/signal"
 	"github.com/TevvvB/parallel-harness-pets/internal/state"
 	"github.com/TevvvB/parallel-harness-pets/internal/verdict"
+	"github.com/TevvvB/parallel-harness-pets/internal/visits"
 )
 
 var version = "dev"
@@ -234,6 +235,9 @@ func build(directory string, who agent, settings config.Config) (render.View, bo
 		Branch:  repo.Branch,
 		Name:    who.Name,
 	}, now)
+	// A den's memory of who has worked in it. The register above forgets an
+	// agent the moment it moves; this is the half that does not.
+	visits.Record(cacheDir, den, who.SessionID, now)
 
 	view := render.View{
 		Pet:      identity.For(petKey),
@@ -351,6 +355,7 @@ func cardCommand(args []string) {
 		view.Pet = identity.For(representative.Session)
 		view.Session = representative.Session
 	}
+	view.Visitors = visits.ForDen(config.StateDir(), view.Den)
 	fmt.Print(render.Card(view, settings))
 	fmt.Print(updateNotice(settings))
 }

--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -343,7 +343,14 @@ func cardCommand(args []string) {
 	}
 	// The card is a den's readout, so it lists everyone in the den rather than
 	// guessing at a single pet it has no session to identify.
-	view.Residents = agents.InDen(config.StateDir(), view.Den, time.Now())
+	now := time.Now()
+	view.Residents = agents.InDen(config.StateDir(), view.Den, now)
+	// The card runs from a shell with no session of its own, so without this it
+	// shows a branch-derived creature nobody in the den is actually using.
+	if representative, occupied := agents.Representative(view.Residents, now); occupied {
+		view.Pet = identity.For(representative.Session)
+		view.Session = representative.Session
+	}
 	fmt.Print(render.Card(view, settings))
 	fmt.Print(updateNotice(settings))
 }

--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TevvvB/parallel-harness-pets/internal/agents"
 	"github.com/TevvvB/parallel-harness-pets/internal/config"
 	"github.com/TevvvB/parallel-harness-pets/internal/gitrepo"
 	"github.com/TevvvB/parallel-harness-pets/internal/identity"
@@ -85,9 +86,22 @@ func dispatch(args []string) int {
 
 // hookPayload is the shape both Claude Code and Codex pipe into a hook.
 type hookPayload struct {
-	Cwd       string `json:"cwd"`
-	Workspace struct {
+	// SessionID identifies one running agent. It is what makes a pet belong to
+	// an agent rather than to the directory the agent happens to be in.
+	SessionID string `json:"session_id"`
+	// SessionName is the harness's human label for this agent. It is what turns
+	// a list of pets into something readable instead of a column of UUIDs.
+	SessionName string `json:"session_name"`
+	Cwd         string `json:"cwd"`
+	Workspace   struct {
 		CurrentDir string `json:"current_dir"`
+		// GitWorktree and Repo name the den. The harness has already resolved
+		// both, so the render path never has to ask git for them.
+		GitWorktree string `json:"git_worktree"`
+		Repo        struct {
+			Owner string `json:"owner"`
+			Name  string `json:"name"`
+		} `json:"repo"`
 	} `json:"workspace"`
 	Model struct {
 		DisplayName string `json:"display_name"`
@@ -96,6 +110,27 @@ type hookPayload struct {
 		Command string `json:"command"`
 	} `json:"tool_input"`
 	ToolResponse json.RawMessage `json:"tool_response"`
+}
+
+// agent is what a surface knows about the caller: which agent is asking, and
+// which den it is asking from. Every field is optional, because tmux, a shell
+// prompt and `pets card` supply none of them.
+type agent struct {
+	SessionID string
+	Name      string
+	Repo      string
+	Worktree  string
+	Model     string
+}
+
+func (p hookPayload) agent() agent {
+	return agent{
+		SessionID: p.SessionID,
+		Name:      p.SessionName,
+		Repo:      p.Workspace.Repo.Name,
+		Worktree:  p.Workspace.GitWorktree,
+		Model:     p.Model.DisplayName,
+	}
 }
 
 // stdinDeadline bounds how long a surface may take to hand over its payload.
@@ -157,7 +192,7 @@ func (p hookPayload) directory() string {
 
 // build assembles a view from cache only. It never runs git, because this is the
 // path that executes once a second in every open session.
-func build(directory, model string, settings config.Config) (render.View, bool) {
+func build(directory string, who agent, settings config.Config) (render.View, bool) {
 	repo, found := gitrepo.Locate(directory)
 	if !found {
 		return render.View{}, false
@@ -171,13 +206,45 @@ func build(directory, model string, settings config.Config) (render.View, bool) 
 		refreshInBackground(repo.Root)
 	}
 
+	// The pet belongs to the agent. Surfaces with no session to key on — tmux, a
+	// shell prompt, `pets card` — fall back to the branch, which is what the pet
+	// meant before agents were modelled at all.
+	petKey := who.SessionID
+	if petKey == "" {
+		petKey = repo.Branch
+	}
+	// The harness names the den when it can. Git's own layout answers otherwise,
+	// and agrees with the harness: both call this worktree by the same name.
+	worktree := who.Worktree
+	if worktree == "" {
+		worktree = repo.Worktree()
+	}
+	project := who.Repo
+	if project == "" {
+		project = repo.Project()
+	}
+
+	den := identity.DenKey(project, worktree)
+	// Pin this agent to its den. Without this the pet is derived and then
+	// forgotten, so a den can never say who is in it.
+	agents.Touch(cacheDir, agents.Record{
+		Session: who.SessionID,
+		Den:     den,
+		Root:    repo.Root,
+		Branch:  repo.Branch,
+		Name:    who.Name,
+	}, now)
+
 	view := render.View{
-		Pet:      identity.For(repo.Branch),
+		Pet:      identity.For(petKey),
+		Place:    identity.PlaceFor(project, worktree),
+		Den:      den,
+		Session:  who.SessionID,
 		Branch:   repo.Branch,
 		Root:     repo.Root,
 		State:    current,
 		Tests:    tests,
-		Model:    model,
+		Model:    who.Model,
 		HasState: hasState,
 	}
 	if hasState {
@@ -224,9 +291,13 @@ func renderCommand(args []string) {
 	if directory == "" {
 		directory = payload.directory()
 	}
-	view, found := build(directory, payload.Model.DisplayName, settings)
+	view, found := build(directory, payload.agent(), settings)
 	format := flagValue(args, "format", "statusline")
 	if !found {
+		// Outside a worktree an agent is still running, so it keeps breathing in
+		// whichever den it was last seen in. Without this, stepping into /tmp
+		// made a live session vanish from every listing 90 seconds later.
+		agents.Beat(config.StateDir(), payload.SessionID, time.Now())
 		if format == "json" {
 			fmt.Println(`{"ready":false}`)
 		}
@@ -266,10 +337,13 @@ func cardCommand(args []string) {
 	}
 	// The card is on demand, so it can afford to be current rather than cached.
 	probe(repo.Root, settings)
-	view, ok := build(repo.Root, "", settings)
+	view, ok := build(repo.Root, agent{}, settings)
 	if !ok {
 		os.Exit(1)
 	}
+	// The card is a den's readout, so it lists everyone in the den rather than
+	// guessing at a single pet it has no session to identify.
+	view.Residents = agents.InDen(config.StateDir(), view.Den, time.Now())
 	fmt.Print(render.Card(view, settings))
 	fmt.Print(updateNotice(settings))
 }
@@ -353,7 +427,7 @@ func quipCommand() {
 		return
 	}
 	probe(repo.Root, settings)
-	view, ok := build(repo.Root, "", settings)
+	view, ok := build(repo.Root, payload.agent(), settings)
 	if !ok {
 		return
 	}

--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -390,16 +390,32 @@ func probe(root string, settings config.Config) {
 }
 
 func recordCommand() {
-	payload := readPayload()
+	info, err := os.Stdin.Stat()
+	if err != nil || info.Mode()&os.ModeCharDevice != 0 {
+		return
+	}
+	recordFrom(os.Stdin, config.StateDir(), time.Now())
+}
+
+// recordFrom is recordCommand's testable core.
+//
+// It takes the bytes a harness actually pipes in and returns the verdict it
+// wrote, so a test can assert what landed in the cache rather than only what
+// the parser returned. The hook's product is a file with an expiry, and a
+// function that decodes correctly while writing the wrong thing would satisfy
+// any test that only checks a return value.
+func recordFrom(source io.Reader, cacheDir string, now time.Time) (string, bool) {
+	payload := parsePayload(source, stdinDeadline)
 	repo, found := gitrepo.Locate(payload.directory())
 	if !found {
-		return
+		return "", false
 	}
 	result, ok := verdict.Of(payload.ToolInput.Command, responseText(payload.ToolResponse))
 	if !ok {
-		return
+		return "", false
 	}
-	state.WriteTests(config.StateDir(), repo.Key(), result, time.Now())
+	state.WriteTests(cacheDir, repo.Key(), result, now)
+	return result, true
 }
 
 // responseText decodes what a runner actually printed.

--- a/cmd/pets/replay_test.go
+++ b/cmd/pets/replay_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/TevvvB/parallel-harness-pets/internal/gitrepo"
+	"github.com/TevvvB/parallel-harness-pets/internal/state"
+)
+
+// worktree fakes just enough of a checkout for gitrepo.Locate, which reads
+// .git/HEAD and nothing else.
+func worktree(t *testing.T, branch string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	head := []byte("ref: refs/heads/" + branch + "\n")
+	if err := os.WriteFile(filepath.Join(root, ".git", "HEAD"), head, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// fixture returns a captured payload with its recorded worktree path swapped
+// for a real one. Only the path is rewritten: the shape, and every field the
+// code does not read, stay exactly as the harness sent them.
+func fixture(t *testing.T, name, root string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.ReplaceAll(string(raw), "/home/user/code/demo/.worktrees/feat-example", root)
+}
+
+// Replaying real captured bytes, rather than a payload we invented, is the only
+// way to catch the class of bug that already shipped here once: hand-written
+// fixtures encode what the author believes the harness sends, so a test built
+// on one agrees with the mistake.
+//
+// The assertion is on the cache, not the return value. A hook that decodes
+// perfectly and writes the wrong verdict, or the right verdict with a timestamp
+// that never expires, satisfies any test that only checks what came back.
+func TestRecordFromCapturedPayloadWritesAndExpires(t *testing.T) {
+	root := worktree(t, "feat-example")
+	cache := t.TempDir()
+	now := time.Now()
+
+	result, ok := recordFrom(strings.NewReader(fixture(t, "posttooluse.json", root)), cache, now)
+	if !ok {
+		t.Fatal("a real PostToolUse payload was not recorded at all")
+	}
+	if result != "pass" {
+		t.Errorf("recorded %q from a passing `go test` run, want pass", result)
+	}
+
+	// What the hook exists to produce: a verdict another process can read back.
+	key := repoKey(t, root)
+	if stored := state.ReadTests(cache, key, now); stored != "pass" {
+		t.Errorf("cache holds %q, want pass", stored)
+	}
+	// And which stops being trusted, so a green run cannot vouch for code
+	// somebody has been editing for hours.
+	if stale := state.ReadTests(cache, key, now.Add(3*time.Hour)); stale != "unknown" {
+		t.Errorf("a three hour old verdict still read as %q", stale)
+	}
+}
+
+// The status line payload is captured too, because it carries the two fields
+// the whole den and pet model is keyed on. If a harness ever renames either,
+// this is what notices.
+func TestCapturedStatuslinePayloadStillCarriesItsKeys(t *testing.T) {
+	root := worktree(t, "feat-example")
+	payload := parsePayload(strings.NewReader(fixture(t, "statusline.json", root)), time.Second)
+
+	if payload.SessionID == "" {
+		t.Error("no session_id: pets could not be keyed to an agent")
+	}
+	if payload.Workspace.GitWorktree == "" {
+		t.Error("no workspace.git_worktree: dens would fall back to guessing")
+	}
+	if payload.Workspace.Repo.Name == "" {
+		t.Error("no workspace.repo.name: every repo's worktrees would share a den")
+	}
+	if payload.Model.DisplayName == "" {
+		t.Error("no model.display_name")
+	}
+}
+
+func repoKey(t *testing.T, root string) string {
+	t.Helper()
+	located, found := gitrepo.Locate(root)
+	if !found {
+		t.Fatalf("could not locate the worktree at %s", root)
+	}
+	return located.Key()
+}

--- a/cmd/pets/replay_test.go
+++ b/cmd/pets/replay_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,13 +30,23 @@ func worktree(t *testing.T, branch string) string {
 // fixture returns a captured payload with its recorded worktree path swapped
 // for a real one. Only the path is rewritten: the shape, and every field the
 // code does not read, stay exactly as the harness sent them.
+//
+// The replacement is escaped as a JSON string rather than spliced in raw. A
+// Windows temp directory is C:\Users\..., and every backslash in it is an
+// invalid JSON escape, so splicing produces a payload that silently fails to
+// parse and a test that reports every field missing.
 func fixture(t *testing.T, name, root string) string {
 	t.Helper()
 	raw, err := os.ReadFile(filepath.Join("testdata", name))
 	if err != nil {
 		t.Fatal(err)
 	}
-	return strings.ReplaceAll(string(raw), "/home/user/code/demo/.worktrees/feat-example", root)
+	encoded, err := json.Marshal(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	quoted := string(encoded[1 : len(encoded)-1])
+	return strings.ReplaceAll(string(raw), "/home/user/code/demo/.worktrees/feat-example", quoted)
 }
 
 // Replaying real captured bytes, rather than a payload we invented, is the only

--- a/cmd/pets/testdata/posttooluse.json
+++ b/cmd/pets/testdata/posttooluse.json
@@ -1,0 +1,25 @@
+{
+  "session_id": "00000000-0000-0000-0000-000000000000",
+  "transcript_path": "/home/user/.claude/projects/demo/transcript.jsonl",
+  "cwd": "/home/user/code/demo/.worktrees/feat-example",
+  "prompt_id": "11111111-1111-1111-1111-111111111111",
+  "permission_mode": "bypassPermissions",
+  "effort": {
+    "level": "xhigh"
+  },
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "go test ./...",
+    "description": "Run the test suite"
+  },
+  "tool_response": {
+    "stdout": "ok  \tgithub.com/example/demo\t0.204s\n",
+    "stderr": "",
+    "interrupted": false,
+    "isImage": false,
+    "noOutputExpected": false
+  },
+  "tool_use_id": "toolu_00000000000000000000000000",
+  "duration_ms": 1958
+}

--- a/cmd/pets/testdata/statusline.json
+++ b/cmd/pets/testdata/statusline.json
@@ -1,0 +1,64 @@
+{
+  "session_id": "00000000-0000-0000-0000-000000000000",
+  "transcript_path": "/home/user/.claude/projects/demo/transcript.jsonl",
+  "cwd": "/home/user/code/demo/.worktrees/feat-example",
+  "prompt_id": "11111111-1111-1111-1111-111111111111",
+  "effort": {
+    "level": "xhigh"
+  },
+  "session_name": "demo session",
+  "model": {
+    "id": "claude-opus-5[1m]",
+    "display_name": "Opus 5 (1M context)"
+  },
+  "workspace": {
+    "current_dir": "/home/user/code/demo/.worktrees/feat-example",
+    "project_dir": "/home/user/code/demo/.worktrees/feat-example",
+    "added_dirs": [],
+    "git_worktree": "feat-example",
+    "repo": {
+      "host": "github.com",
+      "owner": "example",
+      "name": "demo"
+    }
+  },
+  "version": "2.1.228",
+  "output_style": {
+    "name": "default"
+  },
+  "cost": {
+    "total_cost_usd": 0.01234,
+    "total_duration_ms": 45000,
+    "total_api_duration_ms": 2300,
+    "total_lines_added": 156,
+    "total_lines_removed": 23
+  },
+  "context_window": {
+    "total_input_tokens": 404986,
+    "total_output_tokens": 3,
+    "context_window_size": 1000000,
+    "current_usage": {
+      "input_tokens": 2,
+      "output_tokens": 3,
+      "cache_creation_input_tokens": 1517,
+      "cache_read_input_tokens": 403467
+    },
+    "used_percentage": 40,
+    "remaining_percentage": 60
+  },
+  "exceeds_200k_tokens": true,
+  "fast_mode": false,
+  "thinking": {
+    "enabled": true
+  },
+  "rate_limits": {
+    "five_hour": {
+      "used_percentage": 38,
+      "resets_at": 1786734600
+    },
+    "seven_day": {
+      "used_percentage": 10,
+      "resets_at": 1787248800
+    }
+  }
+}

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -1,0 +1,233 @@
+// Package agents is the register of who is currently working where.
+//
+// A pet belongs to an agent, not to a directory, so something has to remember
+// which agent is in which den and when it was last heard from. That is this.
+//
+// Every agent writes only its own file, named for its session, so two agents in
+// one worktree never contend for a write and no locking is needed. The register
+// is disposable: a missing or torn file costs a row in a list, never an error.
+package agents
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// Heartbeat is how often an agent bothers to re-record itself. The status
+	// line calls in roughly once a second in every session; writing that often
+	// would put pointless I/O on the one path that must stay cheap.
+	Heartbeat = 10 * time.Second
+	// StaleAfter is when an agent stops counting as live. An agent that exits
+	// never gets to say so, so silence is the only signal available.
+	StaleAfter = 90 * time.Second
+	// Forgotten is when a silent agent stops being listed at all, so a machine
+	// left running for a week does not accumulate ghosts.
+	Forgotten = 12 * time.Hour
+)
+
+// Record is one agent, pinned to the den it is working in.
+type Record struct {
+	// Session is the harness's own id for this agent. It is the key the pet is
+	// derived from, which is what pins a creature to an agent.
+	Session string
+	// Den is the repo-and-worktree key, so agents group without consulting git.
+	Den string
+	// Root is the worktree path, kept for display. It is deliberately not used
+	// to decide whether an agent still exists: a worktree can be deleted out
+	// from under a session that is very much still running.
+	Root string
+	// Name is the harness's human label for the session. It is what makes a
+	// list of agents readable rather than a column of UUIDs.
+	Name   string
+	Branch string
+	Seen   time.Time
+	// Since is when this agent last changed den. Seen says the agent is alive;
+	// Since says how long it has been here, which is a different question once
+	// an agent can move between worktrees.
+	Since time.Time
+}
+
+func (r Record) Stale(now time.Time) bool { return now.Sub(r.Seen) >= StaleAfter }
+
+// JustArrived reports an agent that has only recently moved into this den, so a
+// listing can show travel rather than presenting a newcomer as a fixture.
+func (r Record) JustArrived(now time.Time) bool {
+	return !r.Since.IsZero() && now.Sub(r.Since) < time.Minute
+}
+
+// Label is what to show a human: the session's own name when it has one, and a
+// short slice of the id when it does not, so the column is never blank.
+func (r Record) Label() string {
+	if name := strings.TrimSpace(r.Name); name != "" {
+		return name
+	}
+	if len(r.Session) > 8 {
+		return r.Session[:8]
+	}
+	return r.Session
+}
+
+func dir(stateDir string) string { return filepath.Join(stateDir, "agents") }
+
+// fileName keeps a session id safe to use as a filename on every platform,
+// for the same reason the worktree cache key does.
+func fileName(session string) string {
+	var flat strings.Builder
+	for _, char := range session {
+		switch {
+		case char >= 'a' && char <= 'z', char >= 'A' && char <= 'Z',
+			char >= '0' && char <= '9', char == '-':
+			flat.WriteRune(char)
+		default:
+			flat.WriteRune('_')
+		}
+	}
+	return flat.String() + ".agent"
+}
+
+// Touch records an agent as alive, skipping the write when the existing record
+// is recent enough. The status line calls this once a second per session.
+func Touch(stateDir string, record Record, now time.Time) error {
+	if record.Session == "" {
+		return nil
+	}
+	path := filepath.Join(dir(stateDir), fileName(record.Session))
+	record.Since = now
+	if existing, err := read(path); err == nil {
+		if existing.Den == record.Den {
+			// Same den, so the arrival time carries over rather than being reset
+			// by every heartbeat.
+			record.Since = existing.Since
+			if now.Sub(existing.Seen) < Heartbeat {
+				return nil
+			}
+		}
+		// A changed den is written immediately whatever the heartbeat says: the
+		// move is the interesting event, and delaying it loses the arrival time.
+	}
+	if err := os.MkdirAll(dir(stateDir), 0o755); err != nil {
+		return err
+	}
+	record.Seen = now
+	var out strings.Builder
+	fmt.Fprintf(&out, "session=%s\nden=%s\nroot=%s\nbranch=%s\nname=%s\nts=%d\nsince=%d\n",
+		record.Session, record.Den, record.Root, record.Branch,
+		// A newline in a session name would forge a second field on read.
+		strings.ReplaceAll(record.Name, "\n", " "), record.Seen.Unix(), record.Since.Unix())
+	temporary := path + ".tmp"
+	if err := os.WriteFile(temporary, []byte(out.String()), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(temporary, path)
+}
+
+// Beat records an agent as still alive without claiming to know where it is.
+//
+// An agent that steps outside a git worktree is still running, and coupling
+// registration to location made it vanish from every listing after 90 seconds.
+// The last known den is preserved rather than cleared, so the agent stays where
+// you last saw it instead of blinking out and back.
+func Beat(stateDir, session string, now time.Time) error {
+	if session == "" {
+		return nil
+	}
+	existing, err := read(filepath.Join(dir(stateDir), fileName(session)))
+	if err != nil {
+		// Nothing to keep alive: an agent that has never been in a worktree has
+		// no den to show and nothing worth recording.
+		return nil
+	}
+	return Touch(stateDir, existing, now)
+}
+
+func read(path string) (Record, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Record{}, err
+	}
+	record := Record{}
+	for _, line := range strings.Split(string(data), "\n") {
+		name, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		switch name {
+		case "session":
+			record.Session = value
+		case "den":
+			record.Den = value
+		case "root":
+			record.Root = value
+		case "branch":
+			record.Branch = value
+		case "name":
+			record.Name = value
+		case "ts":
+			seconds, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+			if err != nil {
+				return Record{}, err
+			}
+			record.Seen = time.Unix(seconds, 0)
+		case "since":
+			seconds, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+			if err != nil {
+				return Record{}, err
+			}
+			record.Since = time.Unix(seconds, 0)
+		}
+	}
+	if record.Session == "" {
+		return Record{}, fmt.Errorf("no session in %s", path)
+	}
+	return record, nil
+}
+
+// All returns every agent still worth showing, most recently seen first.
+//
+// Silence is the only thing that retires an agent. Pruning on a missing
+// directory used to delete live agents whose worktree had just been removed,
+// which is a rendering concern rather than an existence one.
+func All(stateDir string, now time.Time) []Record {
+	entries, err := os.ReadDir(dir(stateDir))
+	if err != nil {
+		return nil
+	}
+	var found []Record
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".agent") {
+			continue
+		}
+		path := filepath.Join(dir(stateDir), entry.Name())
+		record, err := read(path)
+		if err != nil {
+			os.Remove(path)
+			continue
+		}
+		if now.Sub(record.Seen) >= Forgotten {
+			os.Remove(path)
+			continue
+		}
+		found = append(found, record)
+	}
+	sort.Slice(found, func(first, second int) bool {
+		return found[first].Seen.After(found[second].Seen)
+	})
+	return found
+}
+
+// InDen returns the agents working in one den, most recently seen first.
+func InDen(stateDir, den string, now time.Time) []Record {
+	var found []Record
+	for _, record := range All(stateDir, now) {
+		if record.Den == den {
+			found = append(found, record)
+		}
+	}
+	return found
+}

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -221,6 +221,31 @@ func All(stateDir string, now time.Time) []Record {
 	return found
 }
 
+// Representative picks the agent that should stand for a den.
+//
+// A den always shows a creature, but when somebody is actually working there
+// the creature ought to be theirs rather than one derived from the branch. A
+// live agent always outranks a silent one, however recently the silent one
+// spoke, because a den's face should belong to whoever is still in it.
+//
+// It does not assume the caller sorted anything, so the rule survives a change
+// to how the register is ordered.
+func Representative(records []Record, now time.Time) (Record, bool) {
+	var best Record
+	found := false
+	for _, record := range records {
+		switch {
+		case !found:
+			best, found = record, true
+		case best.Stale(now) && !record.Stale(now):
+			best = record
+		case best.Stale(now) == record.Stale(now) && record.Seen.After(best.Seen):
+			best = record
+		}
+	}
+	return best, found
+}
+
 // InDen returns the agents working in one den, most recently seen first.
 func InDen(stateDir, den string, now time.Time) []Record {
 	var found []Record

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -104,6 +104,36 @@ func TestLocationDoesNotDecideExistence(t *testing.T) {
 	}
 }
 
+// A den always shows a creature, and when somebody is working there it must be
+// theirs. The ordering rule is the interesting part: presence beats recency.
+func TestRepresentativePrefersALiveAgent(t *testing.T) {
+	now := time.Now()
+	live := Record{Session: "live", Seen: now.Add(-2 * time.Minute)}
+	silent := Record{Session: "silent", Seen: now.Add(-1 * time.Minute)}
+
+	if _, found := Representative(nil, now); found {
+		t.Error("an empty den named a representative")
+	}
+	// Deliberately unsorted, and the stale one spoke more recently, so a naive
+	// "take the newest" would pick the wrong agent.
+	stale := Record{Session: "stale", Seen: now.Add(-StaleAfter - time.Minute)}
+	chosen, found := Representative([]Record{stale, live}, now)
+	if !found || chosen.Session != "live" {
+		t.Errorf("a stale agent outranked a live one: %q", chosen.Session)
+	}
+	// Among agents in the same condition, the most recent wins.
+	chosen, _ = Representative([]Record{live, silent}, now)
+	if chosen.Session != "silent" {
+		t.Errorf("among live agents the older one won: %q", chosen.Session)
+	}
+	// A den where everyone has gone quiet still gets a face.
+	older := Record{Session: "older", Seen: now.Add(-StaleAfter - time.Hour)}
+	chosen, found = Representative([]Record{older, stale}, now)
+	if !found || chosen.Session != "stale" {
+		t.Errorf("an all-stale den picked %q", chosen.Session)
+	}
+}
+
 // Label is what a human reads in a list, so it must never come back blank.
 func TestLabelFallsBackToTheSessionID(t *testing.T) {
 	named := Record{Session: "aaaa-1111-bbbb", Name: "fix the flaky auth test"}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -1,0 +1,116 @@
+package agents
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The whole reason this package exists: two agents in one worktree used to
+// overwrite each other's state, so a den could only ever show one of them.
+func TestTwoAgentsShareADen(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	for _, session := range []string{"aaaa-1111", "bbbb-2222"} {
+		if err := Touch(dir, Record{Session: session, Den: "demo#feat", Root: dir}, now); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if living := InDen(dir, "demo#feat", now); len(living) != 2 {
+		t.Fatalf("den holds %d agents, want 2", len(living))
+	}
+	if other := InDen(dir, "demo#elsewhere", now); len(other) != 0 {
+		t.Errorf("agents leaked into another den: %d", len(other))
+	}
+}
+
+// An agent that exits never says so, so silence has to be what marks it stale,
+// and a long enough silence has to remove it entirely.
+func TestSilenceGoesStaleThenForgotten(t *testing.T) {
+	dir := t.TempDir()
+	start := time.Now()
+	if err := Touch(dir, Record{Session: "aaaa-1111", Den: "demo#feat", Root: dir}, start); err != nil {
+		t.Fatal(err)
+	}
+	if All(dir, start)[0].Stale(start) {
+		t.Error("a just-seen agent is stale")
+	}
+	later := start.Add(StaleAfter + time.Second)
+	if !All(dir, later)[0].Stale(later) {
+		t.Error("a silent agent never went stale")
+	}
+	if living := All(dir, start.Add(Forgotten+time.Minute)); len(living) != 0 {
+		t.Errorf("a long-silent agent was still listed: %d", len(living))
+	}
+}
+
+// An agent can move between worktrees. Its identity travels with it, it leaves
+// no ghost behind, and the arrival time resets so travel is visible.
+func TestAgentJumpsWorktrees(t *testing.T) {
+	dir := t.TempDir()
+	start := time.Now()
+	if err := Touch(dir, Record{Session: "aaaa-1111", Den: "demo#first", Root: dir}, start); err != nil {
+		t.Fatal(err)
+	}
+	// Well inside the heartbeat window: a move must still be written at once,
+	// or the arrival is lost and the agent appears in the wrong den.
+	moved := start.Add(2 * time.Second)
+	if err := Touch(dir, Record{Session: "aaaa-1111", Den: "demo#second", Root: dir}, moved); err != nil {
+		t.Fatal(err)
+	}
+	if left := InDen(dir, "demo#first", moved); len(left) != 0 {
+		t.Errorf("a ghost stayed behind in the old den: %d", len(left))
+	}
+	arrived := InDen(dir, "demo#second", moved)
+	if len(arrived) != 1 {
+		t.Fatalf("agent did not arrive in the new den: %d", len(arrived))
+	}
+	if !arrived[0].JustArrived(moved) {
+		t.Error("arrival time did not reset on the move")
+	}
+	// Staying put must not keep resetting the arrival clock.
+	settled := moved.Add(Heartbeat + time.Second)
+	if err := Touch(dir, Record{Session: "aaaa-1111", Den: "demo#second", Root: dir}, settled); err != nil {
+		t.Fatal(err)
+	}
+	if InDen(dir, "demo#second", settled)[0].Since != arrived[0].Since {
+		t.Error("a heartbeat in the same den reset the arrival time")
+	}
+}
+
+// An agent outside any worktree, or one whose worktree was deleted underneath
+// it, is still running. Neither may retire it: only silence does.
+func TestLocationDoesNotDecideExistence(t *testing.T) {
+	dir := t.TempDir()
+	start := time.Now()
+	if err := Touch(dir, Record{Session: "aaaa-1111", Den: "demo#gone",
+		Root: filepath.Join(dir, "deleted-worktree")}, start); err != nil {
+		t.Fatal(err)
+	}
+	if living := All(dir, start); len(living) != 1 {
+		t.Fatalf("a live agent was pruned for a missing worktree: %d", len(living))
+	}
+	// Beat keeps it alive without knowing where it is, holding the last den.
+	later := start.Add(Heartbeat + time.Second)
+	if err := Beat(dir, "aaaa-1111", later); err != nil {
+		t.Fatal(err)
+	}
+	held := All(dir, later)
+	if len(held) != 1 || held[0].Den != "demo#gone" {
+		t.Fatalf("Beat lost the agent or its den: %+v", held)
+	}
+	if held[0].Stale(later) {
+		t.Error("Beat did not refresh the agent's liveness")
+	}
+}
+
+// Label is what a human reads in a list, so it must never come back blank.
+func TestLabelFallsBackToTheSessionID(t *testing.T) {
+	named := Record{Session: "aaaa-1111-bbbb", Name: "fix the flaky auth test"}
+	if named.Label() != "fix the flaky auth test" {
+		t.Errorf("named session labelled %q", named.Label())
+	}
+	if unnamed := (Record{Session: "aaaa-1111-bbbb"}).Label(); unnamed != "aaaa-111" {
+		t.Errorf("unnamed session labelled %q", unnamed)
+	}
+}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -94,6 +94,26 @@ func (r Repo) Key() string {
 	return fmt.Sprintf("%s-%08x", trimmed, digest.Sum32())
 }
 
+// Worktree is the name git itself uses for this worktree, matching what a
+// harness reports as workspace.git_worktree. A linked worktree keeps its git
+// directory at <main>/.git/worktrees/<name>, so the name is already on disk.
+func (r Repo) Worktree() string {
+	if parent := filepath.Dir(r.GitDir); filepath.Base(parent) == "worktrees" {
+		return filepath.Base(r.GitDir)
+	}
+	return filepath.Base(r.Root)
+}
+
+// Project is the repository every one of its worktrees shares, so sibling
+// worktrees of one repo cannot be mistaken for worktrees of another.
+func (r Repo) Project() string {
+	if parent := filepath.Dir(r.GitDir); filepath.Base(parent) == "worktrees" {
+		// <main>/.git/worktrees/<name> -> <main>
+		return filepath.Base(filepath.Dir(filepath.Dir(parent)))
+	}
+	return filepath.Base(r.Root)
+}
+
 // DefaultBranch resolves what this repo calls its trunk, so master and trunk
 // repos are not silently compared against a main that does not exist.
 func DefaultBranch(root, override string) string {

--- a/internal/identity/place.go
+++ b/internal/identity/place.go
@@ -1,0 +1,156 @@
+package identity
+
+import "fmt"
+
+// A Place is the den a worktree lives in.
+//
+// Where a Pet is rolled per agent and is gone when that agent stops, the Place
+// is stable: the same repo and worktree name resolve to the same city on every
+// machine, with nothing stored. Codes are IATA so a contributor adding a city
+// has an external standard to follow rather than an argument to have.
+//
+// There was a decorative glyph beside the code once, and it is not coming back.
+// Sixteen single characters picked for sixteen skylines never read as one
+// family; Dubai's arrow collided with the arrow already meaning "unpushed"; two
+// cities silently shared a glyph because only codes were checked for
+// uniqueness; and half of them were East Asian Ambiguous, so they were narrow
+// here and double-width in a CJK terminal, misaligning every column after them.
+// The drawing does that job, in the surfaces that have room for it.
+type Place struct {
+	Code string
+	Name string
+	// Art is drawn only where there is room: the card and the den, never the
+	// status line. Pure ASCII, so a byte count is a column count.
+	Art [3]string
+}
+
+// ArtWidth is the column budget every city drawing shares, so a den lays out in
+// a grid without measuring anything.
+const ArtWidth = 10
+
+var places = []Place{
+	{"SFO", "San Francisco", [3]string{
+		`  /\  /\  `,
+		` /||__||\ `,
+		`~~~~~~~~~~`}},
+	{"TYO", "Tokyo", [3]string{
+		`__________`,
+		` _|____|_ `,
+		`  |    |  `}},
+	{"NYC", "New York", [3]string{
+		`     |    `,
+		`   _|_|_  `,
+		` _|_|_|_|_`}},
+	{"PAR", "Paris", [3]string{
+		`    /\    `,
+		`   /||\   `,
+		`  /_||_\  `}},
+	{"LON", "London", [3]string{
+		`    ^     `,
+		`   |o|    `,
+		` __|_|____`}},
+	{"CAI", "Cairo", [3]string{
+		`  /\      `,
+		` /  \ /\  `,
+		`/____\/__\`}},
+	{"SYD", "Sydney", [3]string{
+		`   _  _   `,
+		`  / \/ \  `,
+		` /______\ `}},
+	{"BER", "Berlin", [3]string{
+		` ________ `,
+		` |||||||| `,
+		` |_||||_| `}},
+	{"SEA", "Seattle", [3]string{
+		`    |     `,
+		`   /_\    `,
+		`   |_|    `}},
+	{"AMS", "Amsterdam", [3]string{
+		` _  _  _  `,
+		`|_||_||_| `,
+		`|_||_||_| `}},
+	{"RIO", "Rio de Janeiro", [3]string{
+		`   \|/    `,
+		`    |     `,
+		`   /_\    `}},
+	{"IST", "Istanbul", [3]string{
+		` |  __  | `,
+		` | /  \ | `,
+		` |/____\| `}},
+	{"DXB", "Dubai", [3]string{
+		`    |     `,
+		`   /|\    `,
+		`  /_|_\   `}},
+	{"SIN", "Singapore", [3]string{
+		`  ______  `,
+		` || || || `,
+		` || || || `}},
+	{"HKG", "Hong Kong", [3]string{
+		`   _   _  `,
+		`  | |_| | `,
+		` |_|_|_|_|`}},
+	{"MEX", "Mexico City", [3]string{
+		`    __    `,
+		`   /__\   `,
+		`  /____\  `}},
+}
+
+// PlaceFor resolves the den from the repository and the worktree's own name.
+//
+// Deliberately not the branch: a den is a location, and checking out a different
+// branch inside a worktree should not relocate it. Deliberately not the absolute
+// path either, which would bake one machine's directory layout into identity.
+//
+// The repository owner is deliberately absent. A harness payload carries it but
+// `pets card` has no payload, and including it made one worktree resolve to two
+// different cities depending on which surface asked.
+func PlaceFor(repo, worktree string) Place {
+	return places[Hash(DenKey(repo, worktree))%len(places)]
+}
+
+// DenKey names a den for storage and grouping. One string, so agents can be
+// grouped by the den they are in without any of them consulting git.
+func DenKey(repo, worktree string) string {
+	return "place:" + repo + "#" + worktree
+}
+
+// AllPlaces returns the full roster, for the den's completion view.
+func AllPlaces() []Place {
+	roster := make([]Place, len(places))
+	copy(roster, places)
+	return roster
+}
+
+// ValidatePlaces keeps the roster mechanically correct so "add a city" stays a
+// one-line contribution that a test can accept or reject without taste.
+func ValidatePlaces() error {
+	seen := map[string]bool{}
+	for _, place := range places {
+		if len(place.Code) != 3 {
+			return fmt.Errorf("place %q: code must be exactly 3 characters", place.Code)
+		}
+		for _, char := range place.Code {
+			if char < 'A' || char > 'Z' {
+				return fmt.Errorf("place %q: code must be uppercase A-Z", place.Code)
+			}
+		}
+		if seen[place.Code] {
+			return fmt.Errorf("duplicate place %q", place.Code)
+		}
+		seen[place.Code] = true
+		for row, line := range place.Art {
+			// Byte length is the column count only while the art stays ASCII,
+			// which is also what keeps it aligned in every terminal.
+			for _, char := range line {
+				if char > 127 {
+					return fmt.Errorf("place %q art row %d: must be ASCII", place.Code, row)
+				}
+			}
+			if len(line) != ArtWidth {
+				return fmt.Errorf("place %q art row %d: must be exactly %d characters, got %d",
+					place.Code, row, ArtWidth, len(line))
+			}
+		}
+	}
+	return nil
+}

--- a/internal/identity/place_test.go
+++ b/internal/identity/place_test.go
@@ -1,0 +1,25 @@
+package identity
+
+import "testing"
+
+// The roster is the contribution surface, so the rules that make a city
+// acceptable have to be enforced by the suite rather than by review.
+func TestPlaceRosterIsWellFormed(t *testing.T) {
+	if err := ValidatePlaces(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A den is a location. Changing branch inside a worktree must not move it, and
+// the same repo and worktree must land on the same city on any machine.
+func TestPlaceIsStableAndRepoScoped(t *testing.T) {
+	first := PlaceFor("demo", "feat-checkout")
+	if again := PlaceFor("demo", "feat-checkout"); again.Code != first.Code {
+		t.Errorf("same repo and worktree gave %s then %s", first.Code, again.Code)
+	}
+	// Every repository having its own main checkout land on one city was the
+	// bug this keying exists to avoid.
+	if other := PlaceFor("other", "feat-checkout"); other.Code == first.Code {
+		t.Errorf("different repos both resolved to %s", first.Code)
+	}
+}

--- a/internal/render/collection.go
+++ b/internal/render/collection.go
@@ -127,7 +127,7 @@ func Party(views []View, settings config.Config, showAll bool, now time.Time) st
 				note = dim + " · just arrived" + reset
 			}
 			fmt.Fprintf(&out, "       %s%s %s%s  %s%s%s%s\n",
-				tone, pad(pet.Prefix+"•ᴗ•"+pet.Suffix, 9), pad(pet.Name, 8), reset,
+				tone, pad(pet.Prefix+view.face()+pet.Suffix, 9), pad(pet.Name, 8), reset,
 				dim, pad(truncate(resident.Label(), 36), 38), since(resident.Seen, now), note)
 		}
 	}

--- a/internal/render/collection.go
+++ b/internal/render/collection.go
@@ -38,7 +38,7 @@ func rarityHue(rarity identity.Rarity) string {
 
 // Party is the view no single-pet companion can render: every live worktree at
 // once, with the worst signal across all of them called out at the bottom.
-func Party(views []View, settings config.Config, showAll bool) string {
+func Party(views []View, settings config.Config, showAll bool, now time.Time) string {
 	if len(views) == 0 {
 		return fmt.Sprintf("%s(-.-) no worktrees seen yet. open one.%s\n", dim, reset)
 	}
@@ -61,9 +61,24 @@ func Party(views []View, settings config.Config, showAll bool) string {
 		views = views[:limit]
 	}
 
+	living := 0
+	for _, view := range views {
+		for _, resident := range view.Residents {
+			if !resident.Stale(now) {
+				living++
+			}
+		}
+	}
 	var out strings.Builder
-	fmt.Fprintf(&out, "\n  %spets party%s%s%s%d alive%s\n\n",
-		label, reset, strings.Repeat(" ", 34), dim, alive, reset)
+	// "alive" used to count worktrees, which is what made it a lie: a directory
+	// existing says nothing about whether an agent is running in it.
+	summary := fmt.Sprintf("%d dens", alive)
+	if living > 0 {
+		summary = fmt.Sprintf("%d dens · %d agent%s", alive, living,
+			map[bool]string{true: "", false: "s"}[living == 1])
+	}
+	fmt.Fprintf(&out, "\n  %spets party%s%s%s%s%s\n\n",
+		label, reset, strings.Repeat(" ", 30), dim, summary, reset)
 
 	widestSpecies, widestBranch := 0, 0
 	for _, view := range views {
@@ -84,7 +99,12 @@ func Party(views []View, settings config.Config, showAll bool) string {
 		species := pad(view.Pet.Label(), widestSpecies)
 		branch := pad(truncate(view.Branch, settings.Display.BranchLabelMax), widestBranch)
 
-		fmt.Fprintf(&out, "  %s %s%s%s %s%-5s%s %s%s%s  %s",
+		home := ""
+		if place := view.Home(); place != "" {
+			home = dim + pad(place, 4) + reset
+		}
+		fmt.Fprintf(&out, "  %s%s %s%s%s %s%-5s%s %s%s%s  %s",
+			home,
 			body,
 			hue(view.Pet.Color), species, reset,
 			rarityHue(view.Pet.Rarity), view.Pet.Rarity.Stars(), reset,
@@ -94,6 +114,20 @@ func Party(views []View, settings config.Config, showAll bool) string {
 			fmt.Fprintf(&out, "  %s%s%s", warn, strings.Join(flags, " "), reset)
 		}
 		fmt.Fprintln(&out)
+		// The agents living in this den, which is the thing a worktree-shaped
+		// list could never show: two agents here used to be one row.
+		for _, resident := range view.Residents {
+			pet := identity.For(resident.Session)
+			tone, note := hue(pet.Color), ""
+			if resident.Stale(now) {
+				tone, note = dim, dim+" · stale"+reset
+			} else if resident.JustArrived(now) {
+				note = dim + " · just arrived" + reset
+			}
+			fmt.Fprintf(&out, "       %s%s %s%s  %s%s%s%s\n",
+				tone, pad(pet.Prefix+"•ᴗ•"+pet.Suffix, 9), pad(pet.Name, 8), reset,
+				dim, pad(truncate(resident.Label(), 36), 38), since(resident.Seen, now), note)
+		}
 	}
 
 	if hidden > 0 {

--- a/internal/render/collection.go
+++ b/internal/render/collection.go
@@ -99,9 +99,11 @@ func Party(views []View, settings config.Config, showAll bool, now time.Time) st
 		species := pad(view.Pet.Label(), widestSpecies)
 		branch := pad(truncate(view.Branch, settings.Display.BranchLabelMax), widestBranch)
 
+		// Tighter than the status line's "@ XYZ": this is a column to scan down,
+		// so it loses the space and keeps the marker.
 		home := ""
-		if place := view.Home(); place != "" {
-			home = dim + pad(place, 4) + reset
+		if code := view.Place.Code; code != "" {
+			home = dim + pad("@"+code, 5) + reset
 		}
 		fmt.Fprintf(&out, "  %s%s %s%s%s %s%-5s%s %s%s%s  %s",
 			home,

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -257,16 +257,19 @@ func Residents(v View, now time.Time) string {
 	fmt.Fprintf(&out, "\n  %s%d agent%s in this den%s\n\n",
 		dim, living, map[bool]string{true: "", false: "s"}[living == 1], reset)
 
+	// Mood belongs to the worktree, so every agent in a den wears the same face.
+	// A fixed cheerful one here would be a readout that reports nothing.
+	face := v.face()
 	width := 0
 	for _, resident := range v.Residents {
 		pet := identity.For(resident.Session)
-		if size := displayWidth(pet.Prefix + "•ᴗ•" + pet.Suffix); size > width {
+		if size := displayWidth(pet.Prefix + face + pet.Suffix); size > width {
 			width = size
 		}
 	}
 	for _, resident := range v.Residents {
 		pet := identity.For(resident.Session)
-		body := pet.Prefix + "•ᴗ•" + pet.Suffix
+		body := pet.Prefix + face + pet.Suffix
 		marker, tone := "  ", hue(pet.Color)
 		if resident.Session == v.Session {
 			marker = dim + "→ " + reset

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -43,10 +43,14 @@ type View struct {
 	HasState  bool
 }
 
-// Home is the den's compact form: the flight code alone, three ASCII cells
-// whatever the city. The status line has no room for the drawing.
+// Home is the den's compact form: the flight code, marked with an "at" so a
+// reader who has never seen this tool still parses three capitals as a place
+// rather than as an abbreviation they are expected to know.
 func (v View) Home() string {
-	return v.Place.Code
+	if v.Place.Code == "" {
+		return ""
+	}
+	return "@ " + v.Place.Code
 }
 
 func hue(color int) string {
@@ -152,15 +156,16 @@ func truncate(text string, max int) string {
 // Statusline is the one-line form Claude Code refreshes every second.
 func Statusline(v View, settings config.Config) string {
 	color := hue(v.Pet.Color)
-	var parts []string
-	// The den is context and the pet is what you rolled, so the city stays dim
-	// and never competes with the creature for attention.
+	// The pet leads because it is the subject; the den trails it as context and
+	// stays dim so it never competes with the creature for attention.
+	parts := []string{
+		color + v.Body() + reset,
+		color + v.Pet.Name + reset,
+	}
 	if home := v.Home(); home != "" {
 		parts = append(parts, dim+home+reset)
 	}
 	parts = append(parts,
-		color+v.Body()+reset,
-		color+v.Pet.Name+reset,
 		dim+"·"+reset,
 		label+truncate(v.Branch, settings.Display.BranchLabelMax)+reset,
 		v.hearts(),

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/TevvvB/parallel-harness-pets/internal/agents"
 	"github.com/TevvvB/parallel-harness-pets/internal/config"
 	"github.com/TevvvB/parallel-harness-pets/internal/identity"
 	"github.com/TevvvB/parallel-harness-pets/internal/score"
@@ -25,14 +27,26 @@ const (
 
 // View is everything a surface needs, already resolved.
 type View struct {
-	Pet      identity.Pet
-	Branch   string
-	Root     string
-	Score    score.Result
-	State    state.State
-	Tests    string
-	Model    string
-	HasState bool
+	Pet   identity.Pet
+	Place identity.Place
+	// Den is the storage key for this worktree, and Session identifies which
+	// agent is asking, so a surface can mark "you" among a den's residents.
+	Den       string
+	Session   string
+	Residents []agents.Record
+	Branch    string
+	Root      string
+	Score     score.Result
+	State     state.State
+	Tests     string
+	Model     string
+	HasState  bool
+}
+
+// Home is the den's compact form: the flight code alone, three ASCII cells
+// whatever the city. The status line has no room for the drawing.
+func (v View) Home() string {
+	return v.Place.Code
 }
 
 func hue(color int) string {
@@ -138,13 +152,19 @@ func truncate(text string, max int) string {
 // Statusline is the one-line form Claude Code refreshes every second.
 func Statusline(v View, settings config.Config) string {
 	color := hue(v.Pet.Color)
-	parts := []string{
-		color + v.Body() + reset,
-		color + v.Pet.Name + reset,
-		dim + "·" + reset,
-		label + truncate(v.Branch, settings.Display.BranchLabelMax) + reset,
-		v.hearts(),
+	var parts []string
+	// The den is context and the pet is what you rolled, so the city stays dim
+	// and never competes with the creature for attention.
+	if home := v.Home(); home != "" {
+		parts = append(parts, dim+home+reset)
 	}
+	parts = append(parts,
+		color+v.Body()+reset,
+		color+v.Pet.Name+reset,
+		dim+"·"+reset,
+		label+truncate(v.Branch, settings.Display.BranchLabelMax)+reset,
+		v.hearts(),
+	)
 	if flags := v.Flags(settings); v.HasState && len(flags) > 0 {
 		parts = append(parts, warn+strings.Join(flags, " ")+reset)
 	}
@@ -198,6 +218,70 @@ func JSON(v View, settings config.Config) (string, error) {
 	return string(encoded), err
 }
 
+// since is the human form of how long ago an agent was last heard from, which
+// is the only evidence available that it is still running.
+func since(then, now time.Time) string {
+	gap := now.Sub(then)
+	switch {
+	case gap < 45*time.Second:
+		return "just now"
+	case gap < time.Hour:
+		return fmt.Sprintf("%dm ago", int(gap.Minutes()))
+	case gap < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(gap.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(gap.Hours())/24)
+	}
+}
+
+// Residents lists the agents sharing this den, marking which one is asking.
+//
+// This is the view the old model could not express: a worktree held one
+// creature, so a second agent in the same worktree was invisible.
+func Residents(v View, now time.Time) string {
+	if len(v.Residents) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	living := 0
+	for _, resident := range v.Residents {
+		if !resident.Stale(now) {
+			living++
+		}
+	}
+	fmt.Fprintf(&out, "\n  %s%d agent%s in this den%s\n\n",
+		dim, living, map[bool]string{true: "", false: "s"}[living == 1], reset)
+
+	width := 0
+	for _, resident := range v.Residents {
+		pet := identity.For(resident.Session)
+		if size := displayWidth(pet.Prefix + "•ᴗ•" + pet.Suffix); size > width {
+			width = size
+		}
+	}
+	for _, resident := range v.Residents {
+		pet := identity.For(resident.Session)
+		body := pet.Prefix + "•ᴗ•" + pet.Suffix
+		marker, tone := "  ", hue(pet.Color)
+		if resident.Session == v.Session {
+			marker = dim + "→ " + reset
+		}
+		// A stale agent is dimmed rather than hidden: an agent that crashed and
+		// is still on screen is more use than one that silently disappeared.
+		note := ""
+		if resident.Stale(now) {
+			tone, note = dim, dim+"  stale"+reset
+		} else if resident.JustArrived(now) {
+			note = dim + "  just arrived" + reset
+		}
+		fmt.Fprintf(&out, "  %s%s%s%s  %s%s%s  %s%s%s%s\n",
+			marker, tone, pad(body, width), reset,
+			tone, pad(pet.Name, 9), reset,
+			dim, pad(truncate(resident.Label(), 32), 34), since(resident.Seen, now), note)
+	}
+	return out.String()
+}
+
 // Card is the full readout, with every penalised signal called out in amber.
 func Card(v View, settings config.Config) string {
 	var out strings.Builder
@@ -215,8 +299,19 @@ func Card(v View, settings config.Config) string {
 		fmt.Fprintf(&out, "  %s%-14s%s %s\n", dim, name, reset, shown)
 	}
 
+	// The card has room, so the den gets its drawing here. The status line does
+	// not, and only ever sees the glyph and the code.
+	if v.Place.Code != "" {
+		fmt.Fprintf(&out, "\n  %s%s  %s%s\n", dim, v.Home(), v.Place.Name, reset)
+		for _, line := range v.Place.Art {
+			fmt.Fprintf(&out, "  %s%s%s\n", dim, line, reset)
+		}
+	}
 	fmt.Fprintf(&out, "\n  %s%s%s  %s%s%s\n", color, v.Body(), reset, color, v.Pet.Name, reset)
 	fmt.Fprintf(&out, "  %s%s%s\n", dim, strings.Repeat("─", 30), reset)
+	if v.Place.Code != "" {
+		row("den", fmt.Sprintf("%s (%s)", v.Place.Name, v.Place.Code), false)
+	}
 	row("branch", v.Branch, false)
 	row("worktree", v.Root, false)
 	row("mood", fmt.Sprintf("%s  %d/%d", v.hearts(), v.Score.Hearts, score.Max), false)
@@ -231,6 +326,7 @@ func Card(v View, settings config.Config) string {
 	for name, value := range v.State.External {
 		row(name, fmt.Sprint(value), false)
 	}
+	out.WriteString(Residents(v, time.Now()))
 	fmt.Fprintln(&out)
 	return out.String()
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -15,6 +15,7 @@ import (
 	"github.com/TevvvB/parallel-harness-pets/internal/identity"
 	"github.com/TevvvB/parallel-harness-pets/internal/score"
 	"github.com/TevvvB/parallel-harness-pets/internal/state"
+	"github.com/TevvvB/parallel-harness-pets/internal/visits"
 )
 
 const (
@@ -34,13 +35,16 @@ type View struct {
 	Den       string
 	Session   string
 	Residents []agents.Record
-	Branch    string
-	Root      string
-	Score     score.Result
-	State     state.State
-	Tests     string
-	Model     string
-	HasState  bool
+	// Visitors is everyone who has ever worked in this den, including the ones
+	// who have long since moved on.
+	Visitors []visits.Visit
+	Branch   string
+	Root     string
+	Score    score.Result
+	State    state.State
+	Tests    string
+	Model    string
+	HasState bool
 }
 
 // Home is the den's compact form: the flight code, marked with an "at" so a
@@ -290,6 +294,36 @@ func Residents(v View, now time.Time) string {
 	return out.String()
 }
 
+// PassedThrough is the den's memory: agents that worked here and have gone.
+//
+// Only the ones no longer present are listed, because the ones still here are
+// already above under Residents and repeating them reads as double counting.
+func PassedThrough(v View, now time.Time) string {
+	here := map[string]bool{}
+	for _, resident := range v.Residents {
+		here[resident.Session] = true
+	}
+	var gone []visits.Visit
+	for _, visit := range v.Visitors {
+		if !here[visit.Session] {
+			gone = append(gone, visit)
+		}
+	}
+	if len(gone) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	fmt.Fprintf(&out, "\n  %s%d passed through%s\n\n", dim, len(gone), reset)
+	for _, visit := range gone {
+		pet := identity.For(visit.Session)
+		fmt.Fprintf(&out, "    %s%s  %s%s  %s%s\n",
+			hue(pet.Color), pad(pet.Prefix+"-.-"+pet.Suffix, 9),
+			pad(pet.Name, 9), reset,
+			dim+"last here "+since(visit.Last, now), reset)
+	}
+	return out.String()
+}
+
 // Card is the full readout, with every penalised signal called out in amber.
 func Card(v View, settings config.Config) string {
 	var out strings.Builder
@@ -334,7 +368,9 @@ func Card(v View, settings config.Config) string {
 	for name, value := range v.State.External {
 		row(name, fmt.Sprint(value), false)
 	}
-	out.WriteString(Residents(v, time.Now()))
+	now := time.Now()
+	out.WriteString(Residents(v, now))
+	out.WriteString(PassedThrough(v, now))
 	fmt.Fprintln(&out)
 	return out.String()
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/TevvvB/parallel-harness-pets/internal/identity"
 	"github.com/TevvvB/parallel-harness-pets/internal/score"
 	"github.com/TevvvB/parallel-harness-pets/internal/state"
+	"time"
 )
 
 // A terminal renders an emoji in two cells but Go counts it as one rune, so
@@ -66,7 +67,7 @@ func TestPartyColumnsAlign(t *testing.T) {
 		view("chore/deps-bump", 4, false),
 		view("spike/graphql", 1, false),
 	}
-	rendered := stripANSI(Party(views, config.Default(), false))
+	rendered := stripANSI(Party(views, config.Default(), false, time.Now()))
 
 	var starts []int
 	for _, line := range strings.Split(rendered, "\n") {
@@ -94,7 +95,7 @@ func TestPartySortsWorstFirst(t *testing.T) {
 		view("spike/graphql", 1, false),
 		view("feat/oauth-flow", 3, false),
 	}
-	rendered := stripANSI(Party(views, config.Default(), false))
+	rendered := stripANSI(Party(views, config.Default(), false, time.Now()))
 	positions := []int{
 		strings.Index(rendered, "spike/graphql"),
 		strings.Index(rendered, "feat/oauth-flow"),
@@ -109,7 +110,7 @@ func TestPartySortsWorstFirst(t *testing.T) {
 }
 
 func TestPartyWithNoWorktrees(t *testing.T) {
-	if out := Party(nil, config.Default(), false); !strings.Contains(out, "no worktrees") {
+	if out := Party(nil, config.Default(), false, time.Now()); !strings.Contains(out, "no worktrees") {
 		t.Errorf("empty party rendered %q", out)
 	}
 }
@@ -151,7 +152,7 @@ func TestPartyCapsTheListAndSaysWhatItHid(t *testing.T) {
 	}
 
 	settings := config.Default()
-	rendered := stripANSI(Party(views, settings, false))
+	rendered := stripANSI(Party(views, settings, false, time.Now()))
 
 	rows := creatureRows(rendered)
 	if rows != settings.Display.PartyLimit {
@@ -160,9 +161,11 @@ func TestPartyCapsTheListAndSaysWhatItHid(t *testing.T) {
 	if !strings.Contains(rendered, "and 9 more, all at full health") {
 		t.Errorf("did not report what it hid:\n%s", rendered)
 	}
-	// The alive count must stay honest even though the list is truncated.
-	if !strings.Contains(rendered, "21 alive") {
-		t.Error("alive count does not reflect every worktree")
+	// The count must stay honest even though the list is truncated. It counts
+	// dens rather than "alive", because a worktree existing never meant an agent
+	// was running in it.
+	if !strings.Contains(rendered, "21 dens") {
+		t.Error("den count does not reflect every worktree")
 	}
 	// The one that matters must survive the cut.
 	if !strings.Contains(rendered, "spike/graphql") {
@@ -175,7 +178,7 @@ func TestPartyAllShowsEverything(t *testing.T) {
 	for index := 0; index < 20; index++ {
 		views = append(views, view(fmt.Sprintf("agent-task-%d", index), 5, false))
 	}
-	rendered := stripANSI(Party(views, config.Default(), true))
+	rendered := stripANSI(Party(views, config.Default(), true, time.Now()))
 	if got := creatureRows(rendered); got != 20 {
 		t.Errorf("--all showed %d worktrees, want 20", got)
 	}

--- a/internal/visits/visits.go
+++ b/internal/visits/visits.go
@@ -1,0 +1,151 @@
+// Package visits is a den's memory of everyone who has worked in it.
+//
+// The agent register answers who is here now, and deliberately forgets: when an
+// agent moves, its single record is overwritten in place, which is what stops a
+// ghost being left behind. That same property means a den could never say who
+// had passed through. This is the additive half.
+//
+// One file per den-and-session pair, so no two writers ever share a file and no
+// locking is needed, the same trick the register uses. A den's visitors are the
+// files sharing its prefix.
+package visits
+
+import (
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Visit is one agent's history with one den.
+type Visit struct {
+	Session string
+	Den     string
+	First   time.Time
+	Last    time.Time
+}
+
+func dir(stateDir string) string { return filepath.Join(stateDir, "visits") }
+
+// prefix folds a den key into something usable as a filename. The key contains
+// a colon and a hash, neither of which is safe on every platform.
+func prefix(den string) string {
+	digest := fnv.New32a()
+	digest.Write([]byte(den))
+	return fmt.Sprintf("%08x", digest.Sum32())
+}
+
+func safe(session string) string {
+	var flat strings.Builder
+	for _, char := range session {
+		switch {
+		case char >= 'a' && char <= 'z', char >= 'A' && char <= 'Z',
+			char >= '0' && char <= '9', char == '-':
+			flat.WriteRune(char)
+		default:
+			flat.WriteRune('_')
+		}
+	}
+	return flat.String()
+}
+
+func path(stateDir, den, session string) string {
+	return filepath.Join(dir(stateDir), prefix(den)+"-"+safe(session)+".visit")
+}
+
+// Record notes that a session has been in a den, keeping the first arrival and
+// moving the last. Called on the render path, so it writes only when the entry
+// is new or the day has moved on.
+func Record(stateDir, den, session string, now time.Time) error {
+	if den == "" || session == "" {
+		return nil
+	}
+	file := path(stateDir, den, session)
+	visit := Visit{Session: session, Den: den, First: now, Last: now}
+	if existing, err := read(file); err == nil {
+		// First arrival is the fact worth keeping; rewriting it on every render
+		// would turn a history into a clock.
+		visit.First = existing.First
+		if now.Sub(existing.Last) < time.Hour {
+			return nil
+		}
+	}
+	if err := os.MkdirAll(dir(stateDir), 0o755); err != nil {
+		return err
+	}
+	body := fmt.Sprintf("session=%s\nden=%s\nfirst=%d\nlast=%d\n",
+		visit.Session, visit.Den, visit.First.Unix(), visit.Last.Unix())
+	temporary := file + ".tmp"
+	if err := os.WriteFile(temporary, []byte(body), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(temporary, file)
+}
+
+func read(file string) (Visit, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return Visit{}, err
+	}
+	visit := Visit{}
+	for _, line := range strings.Split(string(data), "\n") {
+		name, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		switch name {
+		case "session":
+			visit.Session = value
+		case "den":
+			visit.Den = value
+		case "first", "last":
+			seconds, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+			if err != nil {
+				return Visit{}, err
+			}
+			if name == "first" {
+				visit.First = time.Unix(seconds, 0)
+			} else {
+				visit.Last = time.Unix(seconds, 0)
+			}
+		}
+	}
+	if visit.Session == "" {
+		return Visit{}, fmt.Errorf("no session in %s", file)
+	}
+	return visit, nil
+}
+
+// ForDen returns everyone who has ever worked in a den, first arrival first, so
+// the list reads as a history rather than as a leaderboard.
+func ForDen(stateDir, den string) []Visit {
+	entries, err := os.ReadDir(dir(stateDir))
+	if err != nil {
+		return nil
+	}
+	wanted := prefix(den) + "-"
+	var found []Visit
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), wanted) || !strings.HasSuffix(entry.Name(), ".visit") {
+			continue
+		}
+		visit, err := read(filepath.Join(dir(stateDir), entry.Name()))
+		if err != nil {
+			continue
+		}
+		// The prefix is a hash, so confirm the den rather than trusting a
+		// collision to be impossible.
+		if visit.Den != den {
+			continue
+		}
+		found = append(found, visit)
+	}
+	sort.Slice(found, func(first, second int) bool {
+		return found[first].First.Before(found[second].First)
+	})
+	return found
+}

--- a/internal/visits/visits_test.go
+++ b/internal/visits/visits_test.go
@@ -1,0 +1,56 @@
+package visits
+
+import (
+	"testing"
+	"time"
+)
+
+// A den has to remember everyone who worked in it, including agents that have
+// since moved on. That is the whole point: the live register forgets them.
+func TestDenRemembersEveryoneWhoPassedThrough(t *testing.T) {
+	dir := t.TempDir()
+	start := time.Now()
+	for _, session := range []string{"first", "second"} {
+		if err := Record(dir, "demo#alpha", session, start); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The same agent moving to another den must not be forgotten by the one it
+	// left, which is exactly what the live register does.
+	if err := Record(dir, "demo#beta", "first", start); err != nil {
+		t.Fatal(err)
+	}
+	if seen := ForDen(dir, "demo#alpha"); len(seen) != 2 {
+		t.Errorf("alpha remembers %d visitors, want 2", len(seen))
+	}
+	if seen := ForDen(dir, "demo#beta"); len(seen) != 1 {
+		t.Errorf("beta remembers %d visitors, want 1", len(seen))
+	}
+	if seen := ForDen(dir, "demo#never-visited"); len(seen) != 0 {
+		t.Errorf("an unvisited den remembers %d", len(seen))
+	}
+}
+
+// First arrival is the fact worth keeping. Rewriting it on every render would
+// turn the history into a clock.
+func TestFirstArrivalSurvivesLaterVisits(t *testing.T) {
+	dir := t.TempDir()
+	arrived := time.Now()
+	if err := Record(dir, "demo#alpha", "wanderer", arrived); err != nil {
+		t.Fatal(err)
+	}
+	returned := arrived.Add(4 * time.Hour)
+	if err := Record(dir, "demo#alpha", "wanderer", returned); err != nil {
+		t.Fatal(err)
+	}
+	seen := ForDen(dir, "demo#alpha")
+	if len(seen) != 1 {
+		t.Fatalf("one agent produced %d entries", len(seen))
+	}
+	if !seen[0].First.Equal(arrived.Truncate(time.Second)) {
+		t.Errorf("first arrival moved: %v, want %v", seen[0].First, arrived)
+	}
+	if !seen[0].Last.After(seen[0].First) {
+		t.Error("last seen did not advance on a return visit")
+	}
+}


### PR DESCRIPTION
A reader on r/BuildWithClaude pointed out that a branch-derived creature
identifies a worktree, not a live session, so two agents in one worktree are
indistinguishable and a stopped session leaves state that looks current. He was
right, and the fix went past his suggestion: he proposed bolting an ephemeral
badge onto the existing model, but the model itself was the problem.

## What changed

**A worktree is a den, an agent is a pet.** The den comes from repo plus
worktree name, so checking out a different branch does not relocate it, and it
is rendered as a flight code (`@ DXB`). The pet moved onto the harness
`session_id`, so two agents sharing a worktree finally get two creatures.

**`internal/agents`** is the register of who is working where. One file per
session, so concurrent agents cannot overwrite each other, which was the actual
root cause. It carries the harness's own session name, so a listing reads as
sentences rather than UUIDs.

**Liveness is real.** `party` used to print "43 alive" while counting
directories. It reads `43 dens · 3 agents` now, and staleness comes from silence
on a heartbeat, because an agent that crashes never announces it.

**`internal/visits`** gives a den a memory. The register forgets a departed
agent by design, which is what stops ghosts; this is the additive half, so a den
can say who has passed through.

## Bugs found on the way

- An agent that stepped outside a git worktree stopped registering and vanished
  from every listing after 90 seconds, while still running.
- Deleting a worktree deleted the live agent inside it, because pruning keyed on
  the directory existing.
- The card and the status line could show different dens for one worktree, since
  the payload carries `repo.owner` and `pets card` has no payload.
- Two cities silently shared a glyph; the validator only checked codes.
- Dubai's glyph was the same arrow that already meant "unpushed".

## Tests

`testdata/` now holds payloads captured from a live session rather than written
by hand, because a hand-written fixture encodes what its author believes the
harness sends. This project shipped that exact bug once. The assertions are on
what the hook *wrote* and when it expires, not on what a function returned.