### PR TITLE
Bug fix pass

### DIFF
--- a/cmd/pets/collection.go
+++ b/cmd/pets/collection.go
@@ -109,7 +109,9 @@ func hatchCommand() {
 	if _, err := os.Stat(marker); err == nil {
 		return
 	}
-	os.WriteFile(marker, []byte(time.Now().Format(time.RFC3339)+"\n"), 0o644)
+	if err := os.WriteFile(marker, []byte(time.Now().Format(time.RFC3339)+"\n"), 0o644); err != nil {
+		return
+	}
 
 	// Recording happens before rendering so the position shown is the real one.
 	// The hatch itself is free, but the den entry has to be earned, or a

--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/TevvvB/parallel-harness-pets/internal/config"
 	"github.com/TevvvB/parallel-harness-pets/internal/gitrepo"
 	"github.com/TevvvB/parallel-harness-pets/internal/identity"
+	"github.com/TevvvB/parallel-harness-pets/internal/lock"
 	"github.com/TevvvB/parallel-harness-pets/internal/render"
 	"github.com/TevvvB/parallel-harness-pets/internal/score"
 	"github.com/TevvvB/parallel-harness-pets/internal/signal"
@@ -264,7 +265,7 @@ func refreshInBackground(root string) {
 		return
 	}
 	command := exec.Command(executable, "probe", root)
-	command.Stdout, command.Stderr = nil, nil
+	command.Stdout, command.Stderr = io.Discard, io.Discard
 	if command.Start() == nil {
 		go command.Wait()
 	}
@@ -378,11 +379,11 @@ func probe(root string, settings config.Config) {
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return
 	}
-	lock := filepath.Join(cacheDir, repo.Key()+".lock")
-	if os.Mkdir(lock, 0o755) != nil {
+	lockPath := filepath.Join(cacheDir, repo.Key()+".lock")
+	if !lock.TryAcquire(lockPath, 5*time.Minute) {
 		return
 	}
-	defer os.Remove(lock)
+	defer os.Remove(lockPath)
 	state.Write(cacheDir, repo.Key(), signal.Collect(repo, settings, time.Now()))
 	// A branch earns its den entry on its first commit, which may be long after
 	// the hatch, so the probe is where that gets noticed.
@@ -414,7 +415,9 @@ func recordFrom(source io.Reader, cacheDir string, now time.Time) (string, bool)
 	if !ok {
 		return "", false
 	}
-	state.WriteTests(cacheDir, repo.Key(), result, now)
+	if err := state.WriteTests(cacheDir, repo.Key(), result, now); err != nil {
+		return "", false
+	}
 	return result, true
 }
 

--- a/internal/den/den.go
+++ b/internal/den/den.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/TevvvB/parallel-harness-pets/internal/identity"
+	"github.com/TevvvB/parallel-harness-pets/internal/lock"
 )
 
 const Version = 1
@@ -60,19 +61,11 @@ func Record(dir string, pet identity.Pet, branch string, now time.Time) (bool, e
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return false, err
 	}
-	lock := filepath.Join(dir, "den.lock")
-	acquired := false
-	for attempt := 0; attempt < 50; attempt++ {
-		if os.Mkdir(lock, 0o755) == nil {
-			acquired = true
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if !acquired {
+	lockPath := filepath.Join(dir, "den.lock")
+	if !lock.WaitAcquire(lockPath, 2*time.Minute) {
 		return false, nil
 	}
-	defer os.Remove(lock)
+	defer os.Remove(lockPath)
 
 	collection := Load(dir)
 	key := pet.Key()

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -22,6 +22,11 @@ type Repo struct {
 // Locate walks up from dir looking for .git, honouring the gitdir: pointer file
 // that a linked worktree uses in place of a directory.
 func Locate(dir string) (Repo, bool) {
+	if !filepath.IsAbs(dir) {
+		if abs, err := filepath.Abs(dir); err == nil {
+			dir = abs
+		}
+	}
 	for dir != "" && dir != string(filepath.Separator) {
 		info, err := os.Stat(filepath.Join(dir, ".git"))
 		switch {

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -39,6 +39,24 @@ func TestLocateWalksUpFromASubdirectory(t *testing.T) {
 	}
 }
 
+// Relative paths have to be resolved against the current directory before the
+// walk starts, otherwise a path like "../b" from inside "repo/a" stops at the
+// current directory and misses the repository one level up.
+func TestLocateWalksUpFromRelativePath(t *testing.T) {
+	root := t.TempDir()
+	gitDir := filepath.Join(root, ".git")
+	os.MkdirAll(gitDir, 0o755)
+	os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644)
+	nested := filepath.Join(root, "a", "b")
+	os.MkdirAll(nested, 0o755)
+
+	t.Chdir(filepath.Join(root, "a"))
+	repo, found := Locate("../b")
+	if !found || repo.Root != root {
+		t.Fatalf("Locate(../b) from %s = %+v/%v, want root %q", filepath.Join(root, "a"), repo, found, root)
+	}
+}
+
 // A linked worktree has a .git file pointing elsewhere, not a .git directory.
 // This is the whole point of the project, so it had better work.
 func TestLocateLinkedWorktree(t *testing.T) {

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,0 +1,40 @@
+// Package lock provides directory-based locks that clean up after crashed owners.
+//
+// A directory is used because creation is atomic across processes, and because
+// a file left behind by a killed process looks identical to a live one. The
+// stale timeout is what makes the lock self-healing.
+package lock
+
+import (
+	"os"
+	"time"
+)
+
+// TryAcquire creates a directory-based lock. If a lock already exists but is
+// older than stale, it is removed and acquisition is retried once.
+func TryAcquire(path string, stale time.Duration) bool {
+	if os.Mkdir(path, 0o755) == nil {
+		return true
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if time.Since(info.ModTime()) <= stale {
+		return false
+	}
+	_ = os.Remove(path)
+	return os.Mkdir(path, 0o755) == nil
+}
+
+// WaitAcquire tries to acquire a lock, breaking stale ones and retrying for up
+// to about a second.
+func WaitAcquire(path string, stale time.Duration) bool {
+	for attempt := 0; attempt < 50; attempt++ {
+		if TryAcquire(path, stale) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,0 +1,40 @@
+package lock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTryAcquireCreatesAndRemovesLock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.lock")
+	if !TryAcquire(path, time.Minute) {
+		t.Fatal("could not acquire fresh lock")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("lock directory was not created: %v", err)
+	}
+	if TryAcquire(path, time.Minute) {
+		t.Fatal("acquired the same lock twice while it was fresh")
+	}
+	_ = os.Remove(path)
+	if !TryAcquire(path, time.Minute) {
+		t.Fatal("could not re-acquire lock after removing it")
+	}
+}
+
+func TestTryAcquireBreaksStaleLock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stale.lock")
+	if !TryAcquire(path, time.Minute) {
+		t.Fatal("could not acquire lock")
+	}
+	// Roll the modification time back so the lock looks abandoned.
+	old := time.Now().Add(-2 * time.Minute)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if !TryAcquire(path, time.Second) {
+		t.Fatal("stale lock was not broken")
+	}
+}


### PR DESCRIPTION
A set of small, defensive fixes found during a bug-fix pass.

- **Relative path resolution in `gitrepo.Locate`**: relative paths like `--cwd=../foo` are now resolved against the current directory before walking up the tree, so they no longer stop at `.` and miss the repository above.
- **Honest `recordFrom` errors**: the function now reports failure when it cannot write the test-verdict cache, instead of returning `true` while silently dropping the result.
- **Hatch marker write check**: `hatchCommand` aborts if the per-worktree hatch marker cannot be written, preventing the hatch animation from firing on every `SessionStart`.
- **Background probe stdio**: the background `probe` process no longer inherits `stdout`/`stderr`; its output is sent to `io.Discard` so git errors cannot leak into the status line.
- **Self-healing locks**: added `internal/lock` with stale-lock breaking and used it for both `probe` and `den.Record`. A crashed owner can no longer block cache refreshes or new den entries forever.

All existing tests pass, including with `-race`, and new regression tests cover the relative-path and stale-lock cases.
