### PR TITLE
Add AUR packaging

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,0 +1,19 @@
+pkgbase = parallel-harness-pets-bin
+	pkgdesc = A creature for every coding agent, in a den for every git worktree
+	pkgver = 0.2.0
+	pkgrel = 1
+	url = https://github.com/TevvvB/parallel-harness-pets
+	arch = x86_64
+	arch = aarch64
+	license = MIT
+	provides = parallel-harness-pets
+	provides = pets
+	conflicts = parallel-harness-pets
+	conflicts = pets
+	options = !strip
+	source_x86_64 = parallel-harness-pets_0.2.0_linux_amd64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.0/parallel-harness-pets_0.2.0_linux_amd64.tar.gz
+	sha256sums_x86_64 = 5360fe6b5b3a125903a733b4340d027b7cdf2c6fccbd7b5ab2af103f009dca32
+	source_aarch64 = parallel-harness-pets_0.2.0_linux_arm64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.0/parallel-harness-pets_0.2.0_linux_arm64.tar.gz
+	sha256sums_aarch64 = 8a2be578a629eea378d5342fb62477c7239620b15270a70d351802b31e7069ba
+
+pkgname = parallel-harness-pets-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: TevvvB <45053368+TevvvB@users.noreply.github.com>
+pkgname=parallel-harness-pets-bin
+_pkgname=parallel-harness-pets
+pkgver=0.2.0
+pkgrel=1
+pkgdesc="A creature for every coding agent, in a den for every git worktree"
+arch=('x86_64' 'aarch64')
+url="https://github.com/TevvvB/parallel-harness-pets"
+license=('MIT')
+provides=('parallel-harness-pets' 'pets')
+conflicts=('parallel-harness-pets' 'pets')
+options=('!strip')
+
+source_x86_64=("${_pkgname}_${pkgver}_linux_amd64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}_${pkgver}_linux_amd64.tar.gz")
+source_aarch64=("${_pkgname}_${pkgver}_linux_arm64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}_${pkgver}_linux_arm64.tar.gz")
+
+sha256sums_x86_64=('5360fe6b5b3a125903a733b4340d027b7cdf2c6fccbd7b5ab2af103f009dca32')
+sha256sums_aarch64=('8a2be578a629eea378d5342fb62477c7239620b15270a70d351802b31e7069ba')
+
+package() {
+    install -Dm755 "${srcdir}/pets" "${pkgdir}/usr/bin/pets"
+    install -Dm644 "${srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -Dm644 "${srcdir}/README.md" "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,54 @@
+# AUR package
+
+`parallel-harness-pets-bin` — installs the prebuilt Linux binary from the
+GitHub release, so no Go toolchain is needed on the user's machine.
+
+## First-time publish
+
+Needs an AUR account and the SSH key registered against it, which is why this
+is not automated.
+
+1. Create an account at https://aur.archlinux.org/register and add your public
+   key under My Account → SSH Public Key.
+2. Clone the (empty) package repo and copy these two files in:
+
+   ```sh
+   git clone ssh://aur@aur.archlinux.org/parallel-harness-pets-bin.git
+   cd parallel-harness-pets-bin
+   cp /path/to/claude-buddy/packaging/aur/{PKGBUILD,.SRCINFO} .
+   git add PKGBUILD .SRCINFO
+   git commit -m "Initial import: parallel-harness-pets-bin 0.2.0"
+   git push
+   ```
+
+`.SRCINFO` must be committed alongside `PKGBUILD` — the AUR rejects pushes
+without it, and it must agree with the PKGBUILD or the package shows wrong
+metadata.
+
+## On every release
+
+Bump `pkgver`, reset `pkgrel=1`, and replace both checksums with the ones from
+that release's `checksums.txt`:
+
+```sh
+curl -sL https://github.com/TevvvB/parallel-harness-pets/releases/download/vX.Y.Z/checksums.txt | grep linux
+```
+
+Take the hashes from the published `checksums.txt` rather than hashing a local
+build. The build is not byte-reproducible, so a locally generated hash matches
+nothing anyone downloads and every install fails validation.
+
+On an Arch machine, regenerate `.SRCINFO` properly rather than editing it:
+
+```sh
+makepkg --printsrcinfo > .SRCINFO
+```
+
+## Checked
+
+- Archive layout confirmed: `LICENSE`, `README.md`, `pets` at the archive root,
+  so no `_srcdir` subdirectory handling is needed.
+- `options=('!strip')` because the Go binary is already stripped by GoReleaser
+  and stripping again is wasted work.
+- `provides`/`conflicts` cover `pets` so this cannot be co-installed with a
+  future source-built package of the same tool.


### PR DESCRIPTION
`parallel-harness-pets-bin` — a `-bin` AUR package installing the prebuilt Linux binary from the GitHub release.

Rationale: every distribution channel used so far is a post that decays within hours. A package entry is a search surface — it reaches someone at the moment they want a status line tool. Arch users also skew heavily toward terminal setups with custom status bars.

Contains `PKGBUILD`, `.SRCINFO` (the AUR rejects pushes without it), and a README covering first publish and the per-release bump.

Checksums are taken from the release's published `checksums.txt` and verified against the downloaded artifact, not a local build — the build is not byte-reproducible, so a locally generated hash matches nothing anyone downloads.

Publishing needs an AUR account and registered SSH key, so that step is manual.