### PR TITLE
Translate the README into Japanese, Korean and Simplified Chinese

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,152 @@
+<p align="center">
+  <img src="docs/header.png" alt="parallel-harness-pets" width="100%" />
+</p>
+
+<p align="center">
+  <strong>エージェントごとに一匹のいきもの、git worktree ごとに一つの巣（den）。</strong>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <b>日本語</b> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.zh-Hans.md">简体中文</a>
+</p>
+
+<p align="center">
+  よくあるターミナルペットは <i>あなた</i> のものです。一匹を長く育てる。これは違います。
+  ここでのペットは <b>エージェント</b> のものです。worktree はそれぞれ名前を持つ「巣」になり、
+  そこで動いているエージェントは一匹ずつ自分のいきものを持ちます。機嫌はその worktree の
+  きれいさを映します。エージェントが六つ動いていれば、いきものも六匹同時に生きている。
+  一目で見分けがつくので、どのセッションを見ているのか、どれが困っているのかがすぐ分かります。
+</p>
+
+<p align="center">
+  <img src="docs/demo.gif" alt="六つの worktree、六匹のいきもの" width="100%" />
+</p>
+
+## インストール
+
+**Linux と macOS**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/TevvvB/parallel-harness-pets/main/install.sh | sh
+pets install
+```
+
+**macOS（Homebrew）**
+
+```sh
+brew install TevvvB/tap/parallel-harness-pets
+pets install
+```
+
+**Windows** — [Releases](https://github.com/TevvvB/parallel-harness-pets/releases)
+からアーカイブを取得し、`pets` を `PATH` に置いてから `pets install` を実行してください。
+
+**Go を使う場合** — `go install github.com/TevvvB/parallel-harness-pets/cmd/pets@latest`
+
+`pets install` はインストール済みのエージェントを見つけて自分を組み込みます。触れた設定は
+バックアップし、それ以外の設定はそのまま残します。実行後は新しいセッションを開いてください。
+`pets uninstall` で元に戻せます。
+
+エージェントを入れただけで一度も起動していない場合は設定ディレクトリがまだ無いので、
+`pets install --harness=claude` のように直接指定してください。
+
+## 読み方
+
+| 記号 | 意味 |
+|---|---|
+| `@ DXB` | 巣（den）。どの worktree かを空港コードで表す |
+| `•ᴗ•` `•_•` `¬_¬` `>_<` `@_@` `x_x` | 機嫌。ハート5から0まで |
+| `7△` | 未コミット 7 ファイル |
+| `3↑` | 未プッシュ 3 コミット |
+| `105↓` | trunk からの遅れ。40 を超えたときだけ表示 |
+| `⑂2` | マイグレーションの head が 2 つ |
+| `✗` | 直近のテストまたは lint が失敗 |
+| `-.-` と `·····` | 起動直後、まだ目覚めていない状態 |
+
+ハートは 5 から始まり、未コミットのファイルがあれば 1 減り、15 を超えるとさらに 1、
+未プッシュのコミットがあれば 1、5 を超えるとさらに 1、テストが落ちていれば 2 減ります。
+すべて設定で変えられます。
+
+テスト結果はランナーが明示的に結果を告げたときだけ記録され、2 時間を過ぎた結果は忘れられます。
+すでに直したブランチに赤い印が残り続けることはありません。
+
+## すべての worktree を一度に見る
+
+```
+  pets party                              4 dens · 3 agents
+
+  @PAR (•_•)     otter ✦     refactor/auth-guard  ♥♥♥♥♡  3△
+       (•_•)     otter     fix the flaky auth test               just now
+       /•_•\     cat       audit the session middleware          just now
+  @SYD -[•_•]-   carp  ✦     spike/wasm-build     ♥♥♥♥♡  9△
+       -[•_•]-   carp      port the wasm build to esbuild        just now
+  @MEX {•ᴗ•}     fox   ✦     chore/bump-deps      ♥♥♥♥♥
+  @IST \(•ᴗ•)/   crow  ✦✦✦   docs/api-reference   ♥♥♥♥♥
+
+  worst: otter · uncommitted
+```
+
+状態の悪いものが上に来るので、手当てが必要なものがいちばん目立ちます。エージェントがいる巣には
+その顔ぶれがセッション名つきで並ぶので、同じ worktree を共有する二つのエージェントは
+一匹ではなく二匹として表示されます。誰もいない巣にもいきものはいます。
+一覧が長いときは省略され、`pets party --all` ですべて表示できます。
+
+## 集める
+
+これはガチャです。いきものはセッションごとに孵るので、worktree を新しく開くことがそのまま
+一回分の抽選になります。レアリティは五段階です。
+
+| 段階 | 確率 | |
+|---|---|---|
+| common | 60% | `✦` |
+| uncommon | 25% | `✦✦` |
+| rare | 11% | `✦✦✦` |
+| legendary | 3.5% | `✦✦✦✦` |
+| mythic | 0.5% | `✦✦✦✦✦` |
+
+rare 以上はその段階の色をまとうので、星を数えなくても何を引いたか分かります。
+common と uncommon には独自の色相が割り当てられ、同じ種類でも見分けられます。
+
+色違い（shiny）は 1/128 の独立した抽選なので、common でも「当たり」になり得ます。
+`pets den` でコレクションを確認できます。
+
+いきものはエージェントのものなので、そのセッションが続くあいだだけ生きています。
+つまりセッションを始めるたびに引き直しです。巣のほうは安定していて、同じリポジトリと
+worktree はどのマシンでも同じ都市になります。何も保存せずにです。そして巣は、
+そこで働いたエージェントを去ったあとも覚えています。
+
+## コマンド
+
+| | |
+|---|---|
+| `pets party [--all]` | 生きている worktree すべてを、悪い順に |
+| `pets den` | コレクション |
+| `pets card [path]` | worktree 一つの詳細 |
+| `pets render [--format=…]` | `statusline` / `tmux` / `title` / `json` |
+| `pets install` / `pets uninstall` | エージェントへの組み込みと解除 |
+| `pets version` | |
+
+## 対応エージェント
+
+| エージェント | できること |
+|---|---|
+| Claude Code | フル対応。ステータスライン、孵化、ひとこと |
+| Codex CLI | フックは書いてあるが実機未検証。ペット表示は下のシェル用スニペットで |
+| tmux / シェルプロンプト | フル対応。**どのエージェントでも**動く |
+| エディタ | `pets render --format=json` で自作 |
+
+tmux とシェルの方法はエージェント側に何も要求しないので、Aider でも Amp でも Gemini CLI でも
+動きます。エンドツーエンドで検証できているのは Claude Code だけです。ほかのもので動いた、
+あるいは動かなかった場合は issue を立ててもらえると助かります。
+
+## ライセンス
+
+MIT。[LICENSE](LICENSE) を参照してください。
+
+---
+
+> この翻訳は英語版からの機械翻訳をもとにしています。不自然な表現があれば
+> [issue](https://github.com/TevvvB/parallel-harness-pets/issues) や PR で直してもらえると助かります。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,151 @@
+<p align="center">
+  <img src="docs/header.png" alt="parallel-harness-pets" width="100%" />
+</p>
+
+<p align="center">
+  <strong>에이전트마다 한 마리씩, git worktree마다 하나의 둥지(den).</strong>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <b>한국어</b> ·
+  <a href="README.zh-Hans.md">简体中文</a>
+</p>
+
+<p align="center">
+  흔한 터미널 펫은 <i>당신</i>의 것입니다. 한 마리를 오래 키우죠. 이건 다릅니다.
+  여기서 펫은 <b>에이전트</b>의 것입니다. worktree는 각자 이름을 가진 둥지가 되고,
+  그 안에서 돌아가는 에이전트마다 자기 생물을 하나씩 갖습니다. 기분은 그 worktree가
+  얼마나 깔끔한지를 따라갑니다. 에이전트 여섯 개를 돌리면 생물도 여섯 마리가 동시에 살아 있고,
+  한눈에 구분되기 때문에 지금 보고 있는 세션이 무엇인지, 어느 쪽이 문제인지 바로 알 수 있습니다.
+</p>
+
+<p align="center">
+  <img src="docs/demo.gif" alt="worktree 여섯 개, 생물 여섯 마리" width="100%" />
+</p>
+
+## 설치
+
+**Linux와 macOS**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/TevvvB/parallel-harness-pets/main/install.sh | sh
+pets install
+```
+
+**macOS (Homebrew)**
+
+```sh
+brew install TevvvB/tap/parallel-harness-pets
+pets install
+```
+
+**Windows** — [Releases](https://github.com/TevvvB/parallel-harness-pets/releases)에서
+아카이브를 받아 `pets`를 `PATH`에 두고 `pets install`을 실행하세요.
+
+**Go로 설치** — `go install github.com/TevvvB/parallel-harness-pets/cmd/pets@latest`
+
+`pets install`은 설치된 에이전트를 찾아 스스로를 연결합니다. 건드린 설정은 백업하고
+나머지 설정은 그대로 둡니다. 실행한 뒤에는 새 세션을 여세요. `pets uninstall`로 되돌립니다.
+
+에이전트를 설치만 하고 한 번도 실행하지 않았다면 설정 디렉터리가 아직 없으므로
+`pets install --harness=claude`처럼 직접 지정하세요.
+
+## 읽는 법
+
+| 기호 | 의미 |
+|---|---|
+| `@ DXB` | 둥지(den). 어느 worktree인지를 공항 코드로 |
+| `•ᴗ•` `•_•` `¬_¬` `>_<` `@_@` `x_x` | 기분. 하트 5부터 0까지 |
+| `7△` | 커밋되지 않은 파일 7개 |
+| `3↑` | 푸시되지 않은 커밋 3개 |
+| `105↓` | trunk보다 뒤처진 커밋 수. 40을 넘을 때만 표시 |
+| `⑂2` | 마이그레이션 head가 2개 |
+| `✗` | 마지막 테스트 또는 lint 실패 |
+| `-.-` 와 `·····` | 세션 시작 직후, 아직 깨어나는 중 |
+
+하트는 5에서 시작해 커밋되지 않은 파일이 있으면 1, 15개를 넘으면 하나 더,
+푸시되지 않은 커밋이 있으면 1, 5개를 넘으면 하나 더, 테스트가 깨져 있으면 2가 깎입니다.
+전부 설정으로 바꿀 수 있습니다.
+
+테스트 결과는 러너가 결과를 명확히 말했을 때만 기록되고, 두 시간이 지난 결과는 잊힙니다.
+이미 고친 브랜치에 빨간 표시가 계속 남지 않습니다.
+
+## 모든 worktree를 한 번에 보기
+
+```
+  pets party                              4 dens · 3 agents
+
+  @PAR (•_•)     otter ✦     refactor/auth-guard  ♥♥♥♥♡  3△
+       (•_•)     otter     fix the flaky auth test               just now
+       /•_•\     cat       audit the session middleware          just now
+  @SYD -[•_•]-   carp  ✦     spike/wasm-build     ♥♥♥♥♡  9△
+       -[•_•]-   carp      port the wasm build to esbuild        just now
+  @MEX {•ᴗ•}     fox   ✦     chore/bump-deps      ♥♥♥♥♥
+  @IST \(•ᴗ•)/   crow  ✦✦✦   docs/api-reference   ♥♥♥♥♥
+
+  worst: otter · uncommitted
+```
+
+상태가 나쁜 것이 위로 오기 때문에 손봐야 할 것이 가장 눈에 띕니다. 에이전트가 있는 둥지에는
+세션 이름과 함께 누가 있는지 나열되므로, 같은 worktree를 쓰는 에이전트 둘은 한 마리가 아니라
+두 마리로 보입니다. 비어 있는 둥지에도 생물은 있습니다. 목록이 길면 잘리고,
+`pets party --all`로 전부 볼 수 있습니다.
+
+## 모으기
+
+가챠입니다. 생물은 세션마다 부화하므로, worktree를 새로 여는 것이 곧 한 번의 뽑기입니다.
+등급은 다섯 단계입니다.
+
+| 등급 | 확률 | |
+|---|---|---|
+| common | 60% | `✦` |
+| uncommon | 25% | `✦✦` |
+| rare | 11% | `✦✦✦` |
+| legendary | 3.5% | `✦✦✦✦` |
+| mythic | 0.5% | `✦✦✦✦✦` |
+
+rare 이상은 등급 고유의 색을 입기 때문에 별을 세지 않아도 무엇을 뽑았는지 보입니다.
+common과 uncommon에는 각자의 색조가 배정되어 같은 종이라도 구분됩니다.
+
+이로치(shiny)는 1/128의 별도 뽑기라 common이라도 귀한 것이 될 수 있습니다.
+`pets den`으로 수집 현황을 봅니다.
+
+생물은 에이전트의 것이라 그 세션이 살아 있는 동안만 존재합니다. 즉 세션을 시작할 때마다
+다시 뽑는 셈입니다. 둥지는 안정적인 쪽으로, 같은 저장소와 worktree는 어떤 머신에서도
+같은 도시가 됩니다. 아무것도 저장하지 않고서요. 그리고 둥지는 그곳에서 일했던
+에이전트를 떠난 뒤에도 기억합니다.
+
+## 명령어
+
+| | |
+|---|---|
+| `pets party [--all]` | 살아 있는 worktree 전부, 나쁜 순으로 |
+| `pets den` | 수집 현황 |
+| `pets card [path]` | worktree 하나의 상세 |
+| `pets render [--format=…]` | `statusline` / `tmux` / `title` / `json` |
+| `pets install` / `pets uninstall` | 에이전트에 연결 / 해제 |
+| `pets version` | |
+
+## 지원 에이전트
+
+| 에이전트 | 지원 범위 |
+|---|---|
+| Claude Code | 전체 지원. 상태줄, 부화, 한마디 |
+| Codex CLI | 훅은 작성했으나 실제로 검증하지 못함. 펫 표시는 셸 스니펫으로 |
+| tmux / 셸 프롬프트 | 전체 지원. **모든** 에이전트에서 동작 |
+| 에디터 | `pets render --format=json`으로 직접 구현 |
+
+tmux와 셸 방식은 에이전트에 아무것도 요구하지 않으므로 Aider, Amp, Gemini CLI 등에서도
+동작합니다. 엔드투엔드로 검증된 것은 Claude Code뿐입니다. 다른 것에서 되거나 안 되면
+issue를 남겨주시면 좋겠습니다.
+
+## 라이선스
+
+MIT. [LICENSE](LICENSE)를 참고하세요.
+
+---
+
+> 이 번역은 영어판을 바탕으로 한 기계 번역입니다. 어색한 표현이 있다면
+> [issue](https://github.com/TevvvB/parallel-harness-pets/issues)나 PR로 고쳐주시면 감사하겠습니다.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 </p>
 
 <p align="center">
+  <b>English</b> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.zh-Hans.md">简体中文</a>
+</p>
+
+<p align="center">
   Most terminal pets belong to <i>you</i>: one creature, nurtured over time. This one belongs
   to an <b>agent</b>. Every worktree is a den with a name, every agent working in it gets its
   own creature, and its mood tracks how tidy that worktree is. Six agents means six creatures

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,0 +1,146 @@
+<p align="center">
+  <img src="docs/header.png" alt="parallel-harness-pets" width="100%" />
+</p>
+
+<p align="center">
+  <strong>每个 agent 一只小生物，每个 git worktree 一个巢穴（den）。</strong>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <b>简体中文</b>
+</p>
+
+<p align="center">
+  常见的终端宠物属于 <i>你</i>：养一只，慢慢陪着你。这个不一样。
+  这里的宠物属于 <b>agent</b>。每个 worktree 会变成一个有名字的巢穴，
+  在里面运行的每个 agent 各有一只自己的小生物，它的心情反映那个 worktree 有多干净。
+  同时跑六个 agent，就有六只小生物同时活着，一眼就能分辨，
+  所以你随时知道自己在看哪个会话、哪个出了问题。
+</p>
+
+<p align="center">
+  <img src="docs/demo.gif" alt="六个 worktree，六只小生物" width="100%" />
+</p>
+
+## 安装
+
+**Linux 和 macOS**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/TevvvB/parallel-harness-pets/main/install.sh | sh
+pets install
+```
+
+**macOS（Homebrew）**
+
+```sh
+brew install TevvvB/tap/parallel-harness-pets
+pets install
+```
+
+**Windows** — 从 [Releases](https://github.com/TevvvB/parallel-harness-pets/releases)
+下载压缩包，把 `pets` 放到 `PATH` 里，然后运行 `pets install`。
+
+**用 Go 安装** — `go install github.com/TevvvB/parallel-harness-pets/cmd/pets@latest`
+
+`pets install` 会找到你装了哪些 agent 并把自己接进去。它改动过的配置会先备份，
+其他设置保持原样。装完之后开一个新会话。`pets uninstall` 可以还原。
+
+如果某个 agent 装了但从没运行过，它还没有配置目录，
+这时直接指定即可：`pets install --harness=claude`。
+
+## 怎么读
+
+| 符号 | 含义 |
+|---|---|
+| `@ DXB` | 巢穴（den），用机场代码表示是哪个 worktree |
+| `•ᴗ•` `•_•` `¬_¬` `>_<` `@_@` `x_x` | 心情，从五颗心到零 |
+| `7△` | 7 个未提交的文件 |
+| `3↑` | 3 个未推送的提交 |
+| `105↓` | 落后 trunk 的提交数，超过 40 才显示 |
+| `⑂2` | 迁移树里有 2 个 head |
+| `✗` | 最近一次测试或 lint 失败 |
+| `-.-` 加 `·····` | 会话刚开始，还没睡醒 |
+
+从五颗心开始：有未提交文件扣 1，超过 15 个再扣 1；有未推送提交扣 1，超过 5 个再扣 1；
+测试失败扣 2。这些都可以配置。
+
+只有当 runner 明确说明结果时才会记录测试结果，且超过两小时的结果会被遗忘，
+所以红色标记不会一直挂在你早就修好的分支上。
+
+## 一次看到所有 worktree
+
+```
+  pets party                              4 dens · 3 agents
+
+  @PAR (•_•)     otter ✦     refactor/auth-guard  ♥♥♥♥♡  3△
+       (•_•)     otter     fix the flaky auth test               just now
+       /•_•\     cat       audit the session middleware          just now
+  @SYD -[•_•]-   carp  ✦     spike/wasm-build     ♥♥♥♥♡  9△
+       -[•_•]-   carp      port the wasm build to esbuild        just now
+  @MEX {•ᴗ•}     fox   ✦     chore/bump-deps      ♥♥♥♥♥
+  @IST \(•ᴗ•)/   crow  ✦✦✦   docs/api-reference   ♥♥♥♥♥
+
+  worst: otter · uncommitted
+```
+
+最糟的排在最前面，所以最该处理的一眼就看到。有 agent 的巢穴会列出里面都有谁，
+并带上会话自己的名字，所以共用同一个 worktree 的两个 agent 是两只小生物而不是一只。
+空的巢穴也有小生物。列表太长会截断，`pets party --all` 显示全部。
+
+## 收集
+
+这是扭蛋。小生物按会话孵化，所以每开一个新的 worktree 就等于抽一次。稀有度分五档：
+
+| 稀有度 | 概率 | |
+|---|---|---|
+| common | 60% | `✦` |
+| uncommon | 25% | `✦✦` |
+| rare | 11% | `✦✦✦` |
+| legendary | 3.5% | `✦✦✦✦` |
+| mythic | 0.5% | `✦✦✦✦✦` |
+
+rare 及以上会穿上所属稀有度的颜色，不用数星星就知道抽到了什么。
+common 和 uncommon 各自分到独立色调，所以同一个物种也能区分开。
+
+闪光（shiny）是独立的 1/128 抽取，所以就算是 common 也可能是好东西。
+`pets den` 查看你的收集进度。
+
+小生物属于 agent，只在那个会话存续期间活着，也就是说每开一个会话都是一次新的抽取。
+巢穴是稳定的那一半：同样的仓库加 worktree，在任何机器上都会解析成同一座城市，
+而且不存任何东西。巢穴还会记住在里面工作过的每个 agent，即使它们已经离开。
+
+## 命令
+
+| | |
+|---|---|
+| `pets party [--all]` | 所有活着的 worktree，最糟的在前 |
+| `pets den` | 你的收集 |
+| `pets card [path]` | 单个 worktree 的完整信息 |
+| `pets render [--format=…]` | `statusline` / `tmux` / `title` / `json` |
+| `pets install` / `pets uninstall` | 接入或移除 |
+| `pets version` | |
+
+## 支持的 agent
+
+| Agent | 支持程度 |
+|---|---|
+| Claude Code | 完整支持：状态栏、孵化、吐槽 |
+| Codex CLI | 钩子写好了但没在真实环境验证过。宠物显示请用下面的 shell 方案 |
+| tmux / shell 提示符 | 完整支持，**任何** agent 都能用 |
+| 编辑器 | 用 `pets render --format=json` 自己做 |
+
+tmux 和 shell 这两种方式不需要 agent 提供任何东西，所以 Aider、Amp、Gemini CLI 都能用。
+端到端验证过的只有 Claude Code。如果你用别的跑通了、或者没跑通，欢迎提 issue。
+
+## 许可证
+
+MIT，见 [LICENSE](LICENSE)。
+
+---
+
+> 此翻译基于英文版机器翻译。如果有读起来别扭的地方，
+> 欢迎通过 [issue](https://github.com/TevvvB/parallel-harness-pets/issues) 或 PR 指正。

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,0 +1,19 @@
+pkgbase = parallel-harness-pets-bin
+	pkgdesc = A creature for every coding agent, in a den for every git worktree
+	pkgver = 0.2.0
+	pkgrel = 1
+	url = https://github.com/TevvvB/parallel-harness-pets
+	arch = x86_64
+	arch = aarch64
+	license = MIT
+	provides = parallel-harness-pets
+	provides = pets
+	conflicts = parallel-harness-pets
+	conflicts = pets
+	options = !strip
+	source_x86_64 = parallel-harness-pets_0.2.0_linux_amd64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.0/parallel-harness-pets_0.2.0_linux_amd64.tar.gz
+	sha256sums_x86_64 = 5360fe6b5b3a125903a733b4340d027b7cdf2c6fccbd7b5ab2af103f009dca32
+	source_aarch64 = parallel-harness-pets_0.2.0_linux_arm64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.0/parallel-harness-pets_0.2.0_linux_arm64.tar.gz
+	sha256sums_aarch64 = 8a2be578a629eea378d5342fb62477c7239620b15270a70d351802b31e7069ba
+
+pkgname = parallel-harness-pets-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: TevvvB <45053368+TevvvB@users.noreply.github.com>
+pkgname=parallel-harness-pets-bin
+_pkgname=parallel-harness-pets
+pkgver=0.2.0
+pkgrel=1
+pkgdesc="A creature for every coding agent, in a den for every git worktree"
+arch=('x86_64' 'aarch64')
+url="https://github.com/TevvvB/parallel-harness-pets"
+license=('MIT')
+provides=('parallel-harness-pets' 'pets')
+conflicts=('parallel-harness-pets' 'pets')
+options=('!strip')
+
+source_x86_64=("${_pkgname}_${pkgver}_linux_amd64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}_${pkgver}_linux_amd64.tar.gz")
+source_aarch64=("${_pkgname}_${pkgver}_linux_arm64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}_${pkgver}_linux_arm64.tar.gz")
+
+sha256sums_x86_64=('5360fe6b5b3a125903a733b4340d027b7cdf2c6fccbd7b5ab2af103f009dca32')
+sha256sums_aarch64=('8a2be578a629eea378d5342fb62477c7239620b15270a70d351802b31e7069ba')
+
+package() {
+    install -Dm755 "${srcdir}/pets" "${pkgdir}/usr/bin/pets"
+    install -Dm644 "${srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -Dm644 "${srcdir}/README.md" "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,54 @@
+# AUR package
+
+`parallel-harness-pets-bin` — installs the prebuilt Linux binary from the
+GitHub release, so no Go toolchain is needed on the user's machine.
+
+## First-time publish
+
+Needs an AUR account and the SSH key registered against it, which is why this
+is not automated.
+
+1. Create an account at https://aur.archlinux.org/register and add your public
+   key under My Account → SSH Public Key.
+2. Clone the (empty) package repo and copy these two files in:
+
+   ```sh
+   git clone ssh://aur@aur.archlinux.org/parallel-harness-pets-bin.git
+   cd parallel-harness-pets-bin
+   cp /path/to/claude-buddy/packaging/aur/{PKGBUILD,.SRCINFO} .
+   git add PKGBUILD .SRCINFO
+   git commit -m "Initial import: parallel-harness-pets-bin 0.2.0"
+   git push
+   ```
+
+`.SRCINFO` must be committed alongside `PKGBUILD` — the AUR rejects pushes
+without it, and it must agree with the PKGBUILD or the package shows wrong
+metadata.
+
+## On every release
+
+Bump `pkgver`, reset `pkgrel=1`, and replace both checksums with the ones from
+that release's `checksums.txt`:
+
+```sh
+curl -sL https://github.com/TevvvB/parallel-harness-pets/releases/download/vX.Y.Z/checksums.txt | grep linux
+```
+
+Take the hashes from the published `checksums.txt` rather than hashing a local
+build. The build is not byte-reproducible, so a locally generated hash matches
+nothing anyone downloads and every install fails validation.
+
+On an Arch machine, regenerate `.SRCINFO` properly rather than editing it:
+
+```sh
+makepkg --printsrcinfo > .SRCINFO
+```
+
+## Checked
+
+- Archive layout confirmed: `LICENSE`, `README.md`, `pets` at the archive root,
+  so no `_srcdir` subdirectory handling is needed.
+- `options=('!strip')` because the Go binary is already stripped by GoReleaser
+  and stripping again is wasted work.
+- `provides`/`conflicts` cover `pets` so this cannot be co-installed with a
+  future source-built package of the same tool.


### PR DESCRIPTION
All distribution so far has been English and North American. openpets — the closest comparable project in this niche — ships six localised READMEs, which suggests it is worth doing here.

There is also a product-specific argument: the core mechanic is a gacha, and ガチャ / 가챠 / 扭蛋 are native vocabulary in these languages rather than a concept needing explanation. The translations lead with that framing in the collecting section rather than arriving at it.

Adds `README.ja.md`, `README.ko.md`, `README.zh-Hans.md`, and a language switcher across all four files.

**These need a native pass.** Each carries a footer saying it began as machine translation and inviting corrections. A translation that reads badly is worse than none, and this project's appeal is tonal enough that a literal rendering loses it — flagging that rather than quietly shipping them as finished.