### PR TITLE
Collect cities in the den, not just creatures

### DIFF
--- a/cmd/pets/collection.go
+++ b/cmd/pets/collection.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/TevvvB/parallel-harness-pets/internal/agents"
@@ -16,6 +17,7 @@ import (
 	"github.com/TevvvB/parallel-harness-pets/internal/score"
 	"github.com/TevvvB/parallel-harness-pets/internal/signal"
 	"github.com/TevvvB/parallel-harness-pets/internal/state"
+	"github.com/TevvvB/parallel-harness-pets/internal/visits"
 )
 
 // updateNotice checks at most once a day, and only ever from here: the three
@@ -30,7 +32,24 @@ func updateNotice(settings config.Config) string {
 }
 
 func denCommand() {
-	fmt.Print(render.Den(den.Load(config.StateDir())))
+	cacheDir := config.StateDir()
+	// Cities are collected the same way creatures are, so the den needs both
+	// halves. Which places have been worked in comes out of the visit log,
+	// deduped and resolved back through the same hash that assigned them.
+	seen := map[string]bool{}
+	var visited []identity.Place
+	for _, key := range visits.Dens(cacheDir) {
+		place := identity.PlaceForKey(key)
+		if seen[place.Code] {
+			continue
+		}
+		seen[place.Code] = true
+		visited = append(visited, place)
+	}
+	sort.Slice(visited, func(first, second int) bool {
+		return visited[first].Code < visited[second].Code
+	})
+	fmt.Print(render.Den(den.Load(cacheDir), visited))
 	fmt.Print(updateNotice(config.Load()))
 }
 

--- a/internal/identity/place.go
+++ b/internal/identity/place.go
@@ -24,9 +24,12 @@ type Place struct {
 	Art [3]string
 }
 
-// ArtWidth is the column budget every city drawing shares, so a den lays out in
-// a grid without measuring anything.
-const ArtWidth = 10
+// ArtWidth and ArtRows are the fixed dimensions every city drawing shares, so a
+// den lays out in a grid without measuring anything.
+const (
+	ArtWidth = 10
+	ArtRows  = 3
+)
 
 var places = []Place{
 	{"SFO", "San Francisco", [3]string{
@@ -105,7 +108,17 @@ var places = []Place{
 // `pets card` has no payload, and including it made one worktree resolve to two
 // different cities depending on which surface asked.
 func PlaceFor(repo, worktree string) Place {
-	return places[Hash(DenKey(repo, worktree))%len(places)]
+	return PlaceForKey(DenKey(repo, worktree))
+}
+
+// PlaceForKey resolves a place from a den key that was stored earlier.
+//
+// The visit log records den keys rather than city codes, because a key is what
+// identifies a worktree and a code is only how it is displayed. Reading a place
+// back out therefore needs this, and keeping it beside PlaceFor is what stops
+// the two drifting into disagreeing about the same worktree.
+func PlaceForKey(den string) Place {
+	return places[Hash(den)%len(places)]
 }
 
 // DenKey names a den for storage and grouping. One string, so agents can be
@@ -138,6 +151,9 @@ func ValidatePlaces() error {
 			return fmt.Errorf("duplicate place %q", place.Code)
 		}
 		seen[place.Code] = true
+		if len(place.Art) != ArtRows {
+			return fmt.Errorf("place %q: art must be %d rows", place.Code, ArtRows)
+		}
 		for row, line := range place.Art {
 			// Byte length is the column count only while the art stays ASCII,
 			// which is also what keeps it aligned in every terminal.

--- a/internal/identity/placekey_test.go
+++ b/internal/identity/placekey_test.go
@@ -1,0 +1,16 @@
+package identity
+
+import "testing"
+
+// A place read back from a stored key must be the same place the worktree
+// resolved to when it was written, or the visit log would show cities nobody
+// ever worked in.
+func TestPlaceForKeyAgreesWithPlaceFor(t *testing.T) {
+	for _, c := range [][2]string{{"demo", "feat-a"}, {"demo", "feat-b"}, {"other", "feat-a"}} {
+		direct := PlaceFor(c[0], c[1])
+		viaKey := PlaceForKey(DenKey(c[0], c[1]))
+		if direct.Code != viaKey.Code {
+			t.Errorf("%s/%s: PlaceFor=%s PlaceForKey=%s", c[0], c[1], direct.Code, viaKey.Code)
+		}
+	}
+}

--- a/internal/render/collection.go
+++ b/internal/render/collection.go
@@ -161,8 +161,63 @@ func Party(views []View, settings config.Config, showAll bool, now time.Time) st
 	return out.String()
 }
 
+// Places is the other half of the collection: which cities have been worked in.
+//
+// This is what identity.ArtWidth exists for. Every drawing is the same width, so
+// a grid needs no measuring, and the codes can be centred underneath by
+// arithmetic rather than by rendering and inspecting.
+func Places(visited []identity.Place) string {
+	if len(visited) == 0 {
+		return ""
+	}
+	const perRow = 4
+	const gap = 4
+	var out strings.Builder
+	fmt.Fprintf(&out, "\n  %splaces worked in%s\n\n", dim, reset)
+	for start := 0; start < len(visited); start += perRow {
+		end := start + perRow
+		if end > len(visited) {
+			end = len(visited)
+		}
+		row := visited[start:end]
+		for line := 0; line < identity.ArtRows; line++ {
+			out.WriteString("  ")
+			for column, place := range row {
+				if column > 0 {
+					out.WriteString(strings.Repeat(" ", gap))
+				}
+				drawing := place.Art[line]
+				if column == len(row)-1 {
+					// The drawings are padded to ArtWidth, which is what makes the
+					// grid line up, but on the last column that padding is just
+					// trailing whitespace on the line.
+					drawing = strings.TrimRight(drawing, " ")
+				}
+				fmt.Fprintf(&out, "%s%s%s", dim, drawing, reset)
+			}
+			out.WriteString("\n")
+		}
+		out.WriteString("  ")
+		for column, place := range row {
+			if column > 0 {
+				out.WriteString(strings.Repeat(" ", gap))
+			}
+			// Centred by arithmetic, which only works because every drawing is
+			// exactly ArtWidth wide. The right pad is dropped on the last column
+			// so no line carries trailing whitespace.
+			left := (identity.ArtWidth - len(place.Code)) / 2
+			fmt.Fprintf(&out, "%s%s%s%s", strings.Repeat(" ", left), label, place.Code, reset)
+			if column < len(row)-1 {
+				fmt.Fprint(&out, strings.Repeat(" ", identity.ArtWidth-len(place.Code)-left))
+			}
+		}
+		out.WriteString("\n\n")
+	}
+	return out.String()
+}
+
 // Den is the collection view: what you have hatched, and what is still missing.
-func Den(collection den.Den) string {
+func Den(collection den.Den, visited []identity.Place) string {
 	var out strings.Builder
 	progress := collection.Completion()
 	have, total := 0, 0
@@ -171,8 +226,9 @@ func Den(collection den.Den) string {
 		total += band.Total
 	}
 
-	fmt.Fprintf(&out, "\n  %spets den%s%s%d/%d species · %d shiny%s\n\n",
-		label, reset, strings.Repeat(" ", 22), have, total, collection.ShinyCount(), reset)
+	fmt.Fprintf(&out, "\n  %spets den%s%s%d/%d species · %d shiny · %d/%d places%s\n\n",
+		label, reset, strings.Repeat(" ", 14), have, total, collection.ShinyCount(),
+		len(visited), len(identity.AllPlaces()), reset)
 
 	const width = 20
 	for _, band := range progress {
@@ -186,6 +242,8 @@ func Den(collection den.Den) string {
 			dim, strings.Repeat("░", width-filled), reset,
 			dim, band.Have, band.Total, reset)
 	}
+
+	out.WriteString(Places(visited))
 
 	if latest := collection.Latest(1); len(latest) > 0 {
 		entry := latest[0]

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -198,3 +198,44 @@ func creatureRows(rendered string) int {
 	}
 	return rows
 }
+
+// The places grid centres codes by arithmetic and wraps at a fixed width, both
+// of which are easy to get subtly wrong and invisible until someone squints at
+// a terminal. It also must not emit trailing whitespace.
+func TestPlacesGridAlignsAndWraps(t *testing.T) {
+	roster := identity.AllPlaces()
+	if len(roster) < 6 {
+		t.Skip("roster too small to exercise wrapping")
+	}
+	rendered := stripANSI(Places(roster[:6]))
+	lines := strings.Split(strings.TrimRight(rendered, "\n"), "\n")
+
+	for i, line := range lines {
+		if strings.HasSuffix(line, " ") {
+			t.Errorf("line %d has trailing whitespace: %q", i, line)
+		}
+	}
+	// Six places at four per row means two rows, and each row is three drawing
+	// lines plus a code line.
+	codeLines := 0
+	for _, line := range lines {
+		if strings.Contains(line, roster[0].Code) || strings.Contains(line, roster[4].Code) {
+			codeLines++
+		}
+	}
+	if codeLines != 2 {
+		t.Errorf("expected 2 code rows for 6 places at 4 per row, found %d", codeLines)
+	}
+	// A code must sit under its own drawing, not at the left margin.
+	for _, line := range lines {
+		if strings.Contains(line, roster[0].Code) {
+			if strings.HasPrefix(strings.TrimLeft(line, " "), roster[0].Code) &&
+				len(line)-len(strings.TrimLeft(line, " ")) < 3 {
+				t.Errorf("code not centred under its drawing: %q", line)
+			}
+		}
+	}
+	if Places(nil) != "" {
+		t.Error("an empty roster still rendered a grid")
+	}
+}

--- a/internal/visits/visits.go
+++ b/internal/visits/visits.go
@@ -120,6 +120,34 @@ func read(file string) (Visit, error) {
 	return visit, nil
 }
 
+// Dens returns every den that has ever been visited, so the collection can ask
+// which places have been worked in rather than only who came to one of them.
+//
+// The filename carries a hash of the den key rather than the key itself, so the
+// keys have to be read out of the files. Duplicates are expected: one file per
+// den-and-session pair means a den with four visitors has four files.
+func Dens(stateDir string) []string {
+	entries, err := os.ReadDir(dir(stateDir))
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var found []string
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".visit") {
+			continue
+		}
+		visit, err := read(filepath.Join(dir(stateDir), entry.Name()))
+		if err != nil || visit.Den == "" || seen[visit.Den] {
+			continue
+		}
+		seen[visit.Den] = true
+		found = append(found, visit.Den)
+	}
+	sort.Strings(found)
+	return found
+}
+
 // ForDen returns everyone who has ever worked in a den, first arrival first, so
 // the list reads as a history rather than as a leaderboard.
 func ForDen(stateDir, den string) []Visit {

--- a/internal/visits/visits_test.go
+++ b/internal/visits/visits_test.go
@@ -54,3 +54,29 @@ func TestFirstArrivalSurvivesLaterVisits(t *testing.T) {
 		t.Error("last seen did not advance on a return visit")
 	}
 }
+
+// The collection needs to ask which places have been worked in, which means
+// reading distinct den keys back out of a directory of per-session files.
+func TestDensListsEachDenOnce(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	for _, v := range [][2]string{
+		{"demo#alpha", "one"}, {"demo#alpha", "two"}, {"demo#alpha", "three"},
+		{"demo#beta", "one"}, {"other#alpha", "one"},
+	} {
+		if err := Record(dir, v[0], v[1], now); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dens := Dens(dir)
+	if len(dens) != 3 {
+		t.Fatalf("got %d dens %v, want 3 distinct", len(dens), dens)
+	}
+	// Sorted, so the caller gets a stable order between runs.
+	if dens[0] != "demo#alpha" || dens[1] != "demo#beta" || dens[2] != "other#alpha" {
+		t.Errorf("unsorted or wrong: %v", dens)
+	}
+	if empty := Dens(t.TempDir()); len(empty) != 0 {
+		t.Errorf("a fresh state dir reported %d dens", len(empty))
+	}
+}


### PR DESCRIPTION
`pets den` showed creatures and nothing else. It now shows both halves of the collection.

```
  pets den              7/41 species · 2 shiny · 6/16 places

  COMMON      ████████░░░░░░░░░░░░  6/14
  ...

  places worked in

   _  _  _          |              |            /\
  |_||_||_|        /|\           _|_|_         /||\
  |_||_||_|       /_|_\        _|_|_|_|_      /_||_\
     AMS           DXB           NYC           PAR
```

**This was already promised in three places.** `AllPlaces()` was documented "for the den's completion view" and had no callers. `ArtWidth` claimed to exist "so a den lays out in a grid without measuring anything" — there was no grid. The drawings rendered only on the card. The scaffolding existed; the room didn't.

The visit log had the mirror problem: it could answer *who came to this den* but not *which dens have been worked in*, so the data was recorded and unreachable.

**Additions**
- `identity.PlaceForKey` — resolves a place from a stored den key, since the log records keys rather than codes. Kept beside `PlaceFor`, with a test that they agree, so the two can't drift about one worktree.
- `visits.Dens` — distinct dens, deduping the per-session files.
- `identity.ArtRows` — the grid loop states its bound instead of hardcoding 3, and `Validate` now enforces it so the constant and the array type can't silently disagree.

**Tests** cover the two new functions plus the grid's centring arithmetic, its wrap at four per row, and that it emits no trailing whitespace — the drawings are padded to `ArtWidth`, which is what makes the grid align but would otherwise leave whitespace at every line end.