### PR TITLE
Add a code of conduct, a pull request template and a sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: tevvvb

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Delete anything that does not apply. A one-line PR is welcome. -->
+
+## What this changes
+
+## Why
+
+## Checks
+
+- [ ] `go test ./...` passes
+- [ ] `gofmt -l .` prints nothing
+
+If the change touches `internal/identity`, the golden test pins branch names to
+creatures on purpose. Repinning it is fine when the reshuffle is deliberate —
+say so here, so a reviewer knows it was not an accident.
+
+If it adds a creature, please confirm it reads at a glance in a real terminal at
+both ends of the mood range, not just in the diff.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at tevan@protonmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,3 +93,8 @@ executes once a second in every open session, so it reads two small files and
 nothing else. The expensive work happens in `pets probe`, backgrounded and
 throttled. Update checks run only from `card`, `party` and `den`, which a person
 types.
+
+## Conduct
+
+By taking part you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). It is the
+Contributor Covenant, unmodified.


### PR DESCRIPTION
Three of the four files GitHub's community checklist looks for were missing, and
one contributor path was quietly broken.

**The broken path:** `.github/ISSUE_TEMPLATE/creature.yml` asks for a `creature`
label, and that label did not exist in the repository. Creature proposals — the
one contribution the CONTRIBUTING guide actively solicits, and the one that needs
no Go — arrived unlabelled and unfilterable. The label now exists.

**`CODE_OF_CONDUCT.md`** is the Contributor Covenant 2.1 with nothing edited but
the contact address. That is deliberate: GitHub only detects the covenant and the
Citizen Code of Conduct, and only verbatim, so a version rewritten in this repo's
voice would read better and register as absent. Reporting goes to
tevan@protonmail.com.

**`.github/PULL_REQUEST_TEMPLATE.md`** is short on purpose, and says so in a
comment — a checklist longer than the change gets deleted rather than filled in.
It asks about the two things a reviewer here cannot infer from a diff: whether an
identity repin was deliberate, and whether a new creature was actually looked at
in a terminal.

**`.github/FUNDING.yml`** points the Sponsor button at the Buy Me a Coffee link
that was already in the README, so it appears in the sidebar and on every issue
instead of only above the fold.