### PR TITLE
Pin actions to commit SHAs, and add Dependabot and CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Actions are pinned to commit SHAs, which is what makes this necessary rather
+  # than optional: a pinned action never moves, so nothing updates it but this.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      # `chore:` is filtered out of release notes by .goreleaser.yaml, which is
+      # where a dependency bump belongs — nowhere.
+      prefix: "chore"
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: stable
           cache: true
@@ -28,8 +28,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: stable
       - name: gofmt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,27 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # A weekly run catches new queries landing against code that has not changed,
+  # which is most of this repository most of the time.
+  schedule:
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
+        with:
+          languages: go
+          build-mode: autobuild
+      - uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,13 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: stable
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
Follow-through on what I told @ralyodio when closing #1.

The argument there was that a credentials/injection/SSRF scanner does not fit
this code: no server, no database, no SQL, no shell-out to a user-controlled
string, and exactly one file in the repository importing `net/http` (a once-a-day
version check). I still think that is right. But it left the class of risk that
*does* fit unaddressed, and it would have been cheap to say so and do nothing.

**The real surface is distribution.** `pets` ships by `curl | sh`, by GoReleaser
archives, and through a Homebrew tap — and every action in CI was a floating
major tag. `actions/checkout@v4` is a moving pointer: whoever controls it decides
what runs in a workflow with `contents: write` at release time. That is the
supply-chain path someone would actually use.

- **Actions pinned to commit SHAs**, with the version in a trailing comment so
  they stay readable. Pinned to the SHAs the current majors already point at
  (v4.4.0, v5.6.0, v6.4.0) rather than bumping to v7 — behaviour is unchanged,
  and a version bump right after cutting v0.2.1 is a separate decision.
- **Dependabot**, weekly, on actions and Go modules. A pinned action never moves,
  so nothing updates it but this; pinning without Dependabot just trades a
  moving-target risk for a stale-dependency one. Bumps are prefixed `chore:`,
  which `.goreleaser.yaml` already filters out of release notes.
- **CodeQL** on push, PR and weekly. The weekly run is the point — new queries
  land against code that has not changed, which is most of this repository most
  of the time.

Nothing here touches the binary.