### PR TITLE
Bump the AUR package to 0.2.1

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = parallel-harness-pets-bin
 	pkgdesc = A creature for every coding agent, in a den for every git worktree
-	pkgver = 0.2.0
+	pkgver = 0.2.1
 	pkgrel = 1
 	url = https://github.com/TevvvB/parallel-harness-pets
 	arch = x86_64
@@ -11,9 +11,9 @@ pkgbase = parallel-harness-pets-bin
 	conflicts = parallel-harness-pets
 	conflicts = pets
 	options = !strip
-	source_x86_64 = parallel-harness-pets_0.2.0_linux_amd64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.0/parallel-harness-pets_0.2.0_linux_amd64.tar.gz
-	sha256sums_x86_64 = 5360fe6b5b3a125903a733b4340d027b7cdf2c6fccbd7b5ab2af103f009dca32
-	source_aarch64 = parallel-harness-pets_0.2.0_linux_arm64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.0/parallel-harness-pets_0.2.0_linux_arm64.tar.gz
-	sha256sums_aarch64 = 8a2be578a629eea378d5342fb62477c7239620b15270a70d351802b31e7069ba
+	source_x86_64 = parallel-harness-pets_0.2.1_linux_amd64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.1/parallel-harness-pets_0.2.1_linux_amd64.tar.gz
+	sha256sums_x86_64 = 61f6d8e03966bcafba994b00c40d5a124e15dcd30df2a40a7d919d4c79910ab7
+	source_aarch64 = parallel-harness-pets_0.2.1_linux_arm64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.1/parallel-harness-pets_0.2.1_linux_arm64.tar.gz
+	sha256sums_aarch64 = e204b76a9626c6c454b5130ea5aac1117ee5828f7b58555c5c61f337b22fbc55
 
 pkgname = parallel-harness-pets-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: TevvvB <45053368+TevvvB@users.noreply.github.com>
 pkgname=parallel-harness-pets-bin
 _pkgname=parallel-harness-pets
-pkgver=0.2.0
+pkgver=0.2.1
 pkgrel=1
 pkgdesc="A creature for every coding agent, in a den for every git worktree"
 arch=('x86_64' 'aarch64')
@@ -14,8 +14,8 @@ options=('!strip')
 source_x86_64=("${_pkgname}_${pkgver}_linux_amd64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}_${pkgver}_linux_amd64.tar.gz")
 source_aarch64=("${_pkgname}_${pkgver}_linux_arm64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}_${pkgver}_linux_arm64.tar.gz")
 
-sha256sums_x86_64=('5360fe6b5b3a125903a733b4340d027b7cdf2c6fccbd7b5ab2af103f009dca32')
-sha256sums_aarch64=('8a2be578a629eea378d5342fb62477c7239620b15270a70d351802b31e7069ba')
+sha256sums_x86_64=('61f6d8e03966bcafba994b00c40d5a124e15dcd30df2a40a7d919d4c79910ab7')
+sha256sums_aarch64=('e204b76a9626c6c454b5130ea5aac1117ee5828f7b58555c5c61f337b22fbc55')
 
 package() {
     install -Dm755 "${srcdir}/pets" "${pkgdir}/usr/bin/pets"

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -17,7 +17,7 @@ is not automated.
    cd parallel-harness-pets-bin
    cp /path/to/claude-buddy/packaging/aur/{PKGBUILD,.SRCINFO} .
    git add PKGBUILD .SRCINFO
-   git commit -m "Initial import: parallel-harness-pets-bin 0.2.0"
+   git commit -m "Initial import: parallel-harness-pets-bin 0.2.1"
    git push
    ```
 


### PR DESCRIPTION
Mechanical version bump, following `packaging/aur/README.md`.

Both checksums come from the release's own `checksums.txt` rather than a local
build — the build is not byte-reproducible, so a locally generated hash matches
nothing anyone downloads and every install would fail validation.

Verified rather than assumed: downloaded
`parallel-harness-pets_0.2.1_linux_amd64.tar.gz`, confirmed its SHA-256 matches
the value now in the PKGBUILD, and confirmed `LICENSE`, `README.md` and `pets`
are still at the archive root, so `package()` needs no change. The archive also
now carries the three translated READMEs; the PKGBUILD installs only `README.md`,
which is fine.

`.SRCINFO` is updated to agree with the PKGBUILD. It was edited rather than
regenerated, because `makepkg --printsrcinfo` needs an Arch machine — the two
files only differ in `pkgver` and the two hashes, so the edit is mechanical, but
worth regenerating properly before the first AUR push.

The package is still unpublished, so the first-import example in the README now
says 0.2.1.