### PR TITLE
Ignore the pets binary that CONTRIBUTING tells people to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cache/
 .DS_Store
 .lavish/
 dist/
+/pets


### PR DESCRIPTION
CONTRIBUTING's "Working on the code" section says:

```sh
go test ./...
go build ./cmd/pets
```

That second line drops a `pets` binary at the repository root, and nothing in
`.gitignore` covered it. So the documented first step for a new contributor ends
with an untracked file in `git status` that they then have to reason about. I hit
it on a stale clone today, which is how I noticed.

Anchored as `/pets`, not `pets`. The unanchored pattern would also match the
`cmd/pets/` **directory** and silently ignore the entire command source, which is
a much worse bug than the one being fixed. Verified both ways:
`git check-ignore` matches the root binary and does not match `cmd/pets/main.go`.