### PR TITLE
Finish the action bumps, and group them so Dependabot stops splitting them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      # One PR for every action, because Dependabot proposes each `uses:` line
+      # separately and that is broken two ways here: codeql-action/init and
+      # /analyze fail unless they run the identical version, and separate PRs
+      # touching the same workflow file conflict as soon as one of them merges.
+      actions:
+        patterns: ["*"]
     commit-message:
       # `chore:` is filtered out of release notes by .goreleaser.yaml, which is
       # where a dependency bump belongs — nowhere.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
@@ -28,7 +28,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,9 +19,9 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: go
           build-mode: autobuild
-      - uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0


### PR DESCRIPTION
#9 pinned every action to a SHA and added Dependabot. Dependabot then opened six
PRs within minutes, which is the system working — but two of them could never
pass, and a third broke as soon as its sibling merged.

**codeql-action cannot be bumped one half at a time.** `init` and `analyze` came
as PRs #22 and #21, each moving only its own `uses:` line. The action refuses to
run when the halves disagree:

```
Error: Loaded a configuration file for version '4.37.7', but running version '3.37.7'
```

Neither PR could go green alone, and merging either one would have broken CodeQL
on `main` until the other landed.

**Separate PRs on the same file conflict.** #18 (checkout) and #17 (setup-go)
both edit `ci.yml` and `release.yml`. #17 merged; #18 immediately went to
`CONFLICTING`.

## What this does

- Bumps `actions/checkout` to v7.0.1 in all four places, and both
  `codeql-action` subpaths to v4.37.7 **together**.
- **Groups the whole github-actions ecosystem into one Dependabot PR.** For a repo
  with three workflows and four distinct actions, one grouped PR a week is both
  less churn and the only shape that can actually pass.

Supersedes #18, #21 and #22, which I am closing.

`actions/setup-go` (v7.0.0), `goreleaser-action` (v7.2.3) and `BurntSushi/toml`
(v1.6.0) already merged cleanly. Every v7 bump here is the same underlying change
— Node 20 to Node 24 — and nothing in our usage of any of them touches a changed
interface.