### PR TITLE
Register an agent from every hook that carries a payload

### DIFF
--- a/cmd/pets/collection.go
+++ b/cmd/pets/collection.go
@@ -124,6 +124,8 @@ func hatchCommand() {
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return
 	}
+	// Ahead of the marker check, which returns for any worktree that hatched before.
+	registerAgent(cacheDir, repo, payload.agent(), time.Now())
 	marker := hatchMarker(cacheDir, repo.Key())
 	if _, err := os.Stat(marker); err == nil {
 		return

--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -192,6 +192,29 @@ func (p hookPayload) directory() string {
 	return working
 }
 
+// registerAgent pins an agent to its den and returns the den key; every payload path calls it, not only the status line.
+func registerAgent(cacheDir string, repo gitrepo.Repo, who agent, now time.Time) string {
+	worktree := who.Worktree
+	if worktree == "" {
+		worktree = repo.Worktree()
+	}
+	project := who.Repo
+	if project == "" {
+		project = repo.Project()
+	}
+	den := identity.DenKey(project, worktree)
+	agents.Touch(cacheDir, agents.Record{
+		Session: who.SessionID,
+		Den:     den,
+		Root:    repo.Root,
+		Branch:  repo.Branch,
+		Name:    who.Name,
+	}, now)
+	// Touch forgets an agent the moment it moves; the visit log is the half that does not.
+	visits.Record(cacheDir, den, who.SessionID, now)
+	return den
+}
+
 // build assembles a view from cache only. It never runs git, because this is the
 // path that executes once a second in every open session.
 func build(directory string, who agent, settings config.Config) (render.View, bool) {
@@ -215,34 +238,11 @@ func build(directory string, who agent, settings config.Config) (render.View, bo
 	if petKey == "" {
 		petKey = repo.Branch
 	}
-	// The harness names the den when it can. Git's own layout answers otherwise,
-	// and agrees with the harness: both call this worktree by the same name.
-	worktree := who.Worktree
-	if worktree == "" {
-		worktree = repo.Worktree()
-	}
-	project := who.Repo
-	if project == "" {
-		project = repo.Project()
-	}
-
-	den := identity.DenKey(project, worktree)
-	// Pin this agent to its den. Without this the pet is derived and then
-	// forgotten, so a den can never say who is in it.
-	agents.Touch(cacheDir, agents.Record{
-		Session: who.SessionID,
-		Den:     den,
-		Root:    repo.Root,
-		Branch:  repo.Branch,
-		Name:    who.Name,
-	}, now)
-	// A den's memory of who has worked in it. The register above forgets an
-	// agent the moment it moves; this is the half that does not.
-	visits.Record(cacheDir, den, who.SessionID, now)
+	den := registerAgent(cacheDir, repo, who, now)
 
 	view := render.View{
 		Pet:      identity.For(petKey),
-		Place:    identity.PlaceFor(project, worktree),
+		Place:    identity.PlaceForKey(den),
 		Den:      den,
 		Session:  who.SessionID,
 		Branch:   repo.Branch,
@@ -411,6 +411,8 @@ func recordFrom(source io.Reader, cacheDir string, now time.Time) (string, bool)
 	if !found {
 		return "", false
 	}
+	// Ahead of the verdict check, which bails on any command that is not a test run.
+	registerAgent(cacheDir, repo, payload.agent(), now)
 	result, ok := verdict.Of(payload.ToolInput.Command, responseText(payload.ToolResponse))
 	if !ok {
 		return "", false
@@ -455,6 +457,8 @@ func quipCommand() {
 	payload := readPayload()
 	repo, found := gitrepo.Locate(payload.directory())
 	if !found {
+		// As on the render path: an agent outside a worktree is still running.
+		agents.Beat(config.StateDir(), payload.SessionID, time.Now())
 		return
 	}
 	probe(repo.Root, settings)

--- a/cmd/pets/replay_test.go
+++ b/cmd/pets/replay_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TevvvB/parallel-harness-pets/internal/agents"
 	"github.com/TevvvB/parallel-harness-pets/internal/gitrepo"
 	"github.com/TevvvB/parallel-harness-pets/internal/state"
 )
@@ -110,4 +111,29 @@ func repoKey(t *testing.T, root string) string {
 		t.Fatalf("could not locate the worktree at %s", root)
 	}
 	return located.Key()
+}
+
+// A tool use that is not a test run still has to register the agent: for a harness with
+// hooks and no status line, this hook is the only per-turn signal that it is alive.
+func TestRecordFromRegistersTheAgentEvenWhenTheCommandIsNotATestRun(t *testing.T) {
+	root := worktree(t, "feat-example")
+	cache := t.TempDir()
+	now := time.Now()
+
+	// The captured payload with only the command swapped, so verdict.Of gives up on it.
+	payload := strings.ReplaceAll(fixture(t, "posttooluse.json", root), "go test ./...", "ls -la")
+	if _, ok := recordFrom(strings.NewReader(payload), cache, now); ok {
+		t.Fatal("`ls -la` was taken for a test verdict")
+	}
+
+	live := agents.All(cache, now)
+	if len(live) != 1 {
+		t.Fatalf("register holds %d agents, want the one that just used a tool", len(live))
+	}
+	if live[0].Session != "00000000-0000-0000-0000-000000000000" {
+		t.Errorf("registered session %q, not the one in the payload", live[0].Session)
+	}
+	if live[0].Den == "" {
+		t.Error("agent registered with no den, so no listing can group it")
+	}
 }


### PR DESCRIPTION
Fixes #11, whose original diagnosis I had wrong - the issue is rewritten with what
the code actually does.

## What was broken

`pets install` wires three hooks for both harnesses, but only one path ever
registered an agent:

| Hook | Command | Registered? |
|---|---|---|
| `SessionStart` | `pets hatch` | no |
| `PostToolUse` | `pets record` | no |
| `Stop` | `pets quip` | yes, via `build` |
| status line | `pets render` | yes, via `build` |

Registration therefore only happened at the **end** of a turn. With hooks and no
status line - Codex, which has no status-line support, or Claude Code with it
switched off - a session was missing from `pets den` and `pets party` for its
entire first turn, and then went **stale** during any turn longer than
`agents.StaleAfter`, because `Stop` does not fire mid-turn. A working agent
rendered dimmed as though it had crashed.

## What this does

Extracts the registration out of `build` into `registerAgent` and calls it from
`hatch` and `record` as well. Both new call sites are deliberately **ahead of an
early return that fires on the common case**: the verdict check gives up on any
command that is not a test run, and the hatch marker returns for every worktree
that has hatched before. Behind either of them the fix would do nothing in
practice, which is worth stating because it is the whole reason the bug existed.

`quip` also now beats when it cannot locate a repo, matching what `render`
already did on that branch.

`build` no longer computes the place itself - `identity.PlaceForKey(den)` answers
from the den key, and #7 added the test pinning it to agree with `PlaceFor` about
the same worktree.

## Note for anyone reading #11's original text

`agents.Beat` could not have fixed this. It returns early when no record exists,
so it keeps a known agent alive and cannot introduce one. The fix had to be a
`Touch` with a den.

## Test

One test, and I checked it fails for the bug rather than assuming it would:
reverting just the `record` call site gives `register holds 0 agents, want the one
that just used a tool`.

It reuses the captured `posttooluse.json` with only the command swapped, so
`verdict.Of` gives up and the old code path returns before registering. Captured
bytes rather than a hand-written payload, per CONTRIBUTING.