### PR TITLE
Bump the AUR package to 0.2.2

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = parallel-harness-pets-bin
 	pkgdesc = A creature for every coding agent, in a den for every git worktree
-	pkgver = 0.2.1
+	pkgver = 0.2.2
 	pkgrel = 1
 	url = https://github.com/TevvvB/parallel-harness-pets
 	arch = x86_64
@@ -11,9 +11,9 @@ pkgbase = parallel-harness-pets-bin
 	conflicts = parallel-harness-pets
 	conflicts = pets
 	options = !strip
-	source_x86_64 = parallel-harness-pets_0.2.1_linux_amd64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.1/parallel-harness-pets_0.2.1_linux_amd64.tar.gz
-	sha256sums_x86_64 = 61f6d8e03966bcafba994b00c40d5a124e15dcd30df2a40a7d919d4c79910ab7
-	source_aarch64 = parallel-harness-pets_0.2.1_linux_arm64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.1/parallel-harness-pets_0.2.1_linux_arm64.tar.gz
-	sha256sums_aarch64 = e204b76a9626c6c454b5130ea5aac1117ee5828f7b58555c5c61f337b22fbc55
+	source_x86_64 = parallel-harness-pets_0.2.2_linux_amd64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.2/parallel-harness-pets_0.2.2_linux_amd64.tar.gz
+	sha256sums_x86_64 = 70511234c65bf41788afa50b451403f6060cc6b501b1324a4a3b8bc73f333486
+	source_aarch64 = parallel-harness-pets_0.2.2_linux_arm64.tar.gz::https://github.com/TevvvB/parallel-harness-pets/releases/download/v0.2.2/parallel-harness-pets_0.2.2_linux_arm64.tar.gz
+	sha256sums_aarch64 = 81d8ba433737f24245a68ebb5ed7029785f3b2af0c90520910491c48ebc399bc
 
 pkgname = parallel-harness-pets-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: TevvvB <45053368+TevvvB@users.noreply.github.com>
 pkgname=parallel-harness-pets-bin
 _pkgname=parallel-harness-pets
-pkgver=0.2.1
+pkgver=0.2.2
 pkgrel=1
 pkgdesc="A creature for every coding agent, in a den for every git worktree"
 arch=('x86_64' 'aarch64')
@@ -14,8 +14,8 @@ options=('!strip')
 source_x86_64=("${_pkgname}_${pkgver}_linux_amd64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}_${pkgver}_linux_amd64.tar.gz")
 source_aarch64=("${_pkgname}_${pkgver}_linux_arm64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}_${pkgver}_linux_arm64.tar.gz")
 
-sha256sums_x86_64=('61f6d8e03966bcafba994b00c40d5a124e15dcd30df2a40a7d919d4c79910ab7')
-sha256sums_aarch64=('e204b76a9626c6c454b5130ea5aac1117ee5828f7b58555c5c61f337b22fbc55')
+sha256sums_x86_64=('70511234c65bf41788afa50b451403f6060cc6b501b1324a4a3b8bc73f333486')
+sha256sums_aarch64=('81d8ba433737f24245a68ebb5ed7029785f3b2af0c90520910491c48ebc399bc')
 
 package() {
     install -Dm755 "${srcdir}/pets" "${pkgdir}/usr/bin/pets"

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -17,7 +17,7 @@ is not automated.
    cd parallel-harness-pets-bin
    cp /path/to/claude-buddy/packaging/aur/{PKGBUILD,.SRCINFO} .
    git add PKGBUILD .SRCINFO
-   git commit -m "Initial import: parallel-harness-pets-bin 0.2.1"
+   git commit -m "Initial import: parallel-harness-pets-bin 0.2.2"
    git push
    ```
 


### PR DESCRIPTION
Follows `packaging/aur/README.md`. Both checksums come from the release's own
`checksums.txt` rather than a local build, since the build is not
byte-reproducible.

Verified rather than assumed, and this time all the way through to the binary:
downloaded `parallel-harness-pets_0.2.2_darwin_arm64.tar.gz`, confirmed its
SHA-256 matches the published value, confirmed `pets version` prints `0.2.2`, and
confirmed `registerAgent` is present in the shipped binary - so the release really
does carry the #26 fix rather than just being tagged after it.

`.SRCINFO` is edited to agree with the PKGBUILD; still regenerate it with
`makepkg --printsrcinfo` on an Arch machine before the first AUR push.

The package remains unpublished, so the first-import example in the README moves
to 0.2.2 with it.