### PR TITLE
Ship as a Claude Code plugin, and make the repo its own marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "name": "parallel-harness-pets",
+  "owner": {
+    "name": "TevvvB",
+    "url": "https://github.com/TevvvB"
+  },
+  "metadata": {
+    "description": "A creature for every agent session, living in your status line",
+    "version": "0.2.2"
+  },
+  "plugins": [
+    {
+      "name": "pets",
+      "source": "./plugin",
+      "description": "The /pets skill plus a one-command setup. Gives every agent session its own creature in the status line, with a den per git worktree, rarity bands and 16 cities to collect.",
+      "version": "0.2.2",
+      "category": "fun",
+      "keywords": [
+        "statusline",
+        "worktree",
+        "parallel-agents",
+        "collection",
+        "fun"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ brew install TevvvB/tap/parallel-harness-pets
 pets install
 ```
 
+**As a Claude Code plugin** - adds `/pets` and `/pets-setup`, so it is findable
+from inside Claude Code:
+
+```
+/plugin marketplace add TevvvB/parallel-harness-pets
+/plugin install pets@parallel-harness-pets
+/pets-setup
+```
+
+The plugin carries the two skills; `pets install` still owns the status line and
+hooks, which is what `/pets-setup` runs. You need the binary either way - a plugin
+carries configuration, not executables. See [plugin/README.md](plugin/README.md).
+
 **Windows** - grab an archive from
 [Releases](https://github.com/TevvvB/parallel-harness-pets/releases), put `pets`
 on your `PATH`, then run `pets install`.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "pets",
+  "version": "0.2.2",
+  "description": "A creature for every agent session, in a den for every git worktree. Its mood tracks how tidy that worktree is, so several agents at once stay tellable apart at a glance.",
+  "author": {
+    "name": "TevvvB",
+    "url": "https://github.com/TevvvB"
+  },
+  "homepage": "https://github.com/TevvvB/parallel-harness-pets",
+  "repository": "https://github.com/TevvvB/parallel-harness-pets",
+  "license": "MIT",
+  "keywords": [
+    "statusline",
+    "worktree",
+    "parallel-agents",
+    "collection",
+    "fun"
+  ]
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,44 @@
+# pets, as a Claude Code plugin
+
+Two skills, and a marketplace entry so people can find this from inside Claude Code
+rather than having to hear about it first.
+
+```
+/plugin marketplace add TevvvB/parallel-harness-pets
+/plugin install pets@parallel-harness-pets
+/pets-setup
+```
+
+| Skill | Does |
+|---|---|
+| `/pets` | Prints this worktree's card - the creature, its mood, and the signals behind it. |
+| `/pets-setup` | Runs `pets install` for you, or tells you how to get the binary if it is missing. |
+
+## What this plugin deliberately does not do
+
+**It does not set the status line.** `statusLine` is not a field Claude Code reads
+from `plugin.json` - `claude plugin validate` says so outright: *"Unknown field
+'statusLine'. Claude Code ignores it at load time."* Several published plugins
+declare it anyway and it silently does nothing for them.
+
+**It does not install the hooks either**, even though a plugin can. `pets install`
+already writes the status line and all three hooks, backs up whatever it touches,
+and reverses cleanly with `pets uninstall`. A plugin that wired the same three hooks
+would double-fire them for anyone who had run the installer, and leave a copy behind
+when either half was removed. One owner for that configuration is worth more than
+saving a step.
+
+So the split is: the plugin is discovery and a way in, `pets install` owns the
+wiring. `/pets-setup` is the seam between them.
+
+## The binary is still a separate step
+
+A plugin carries configuration, not executables:
+
+```sh
+brew install TevvvB/tap/parallel-harness-pets
+# or: go install github.com/TevvvB/parallel-harness-pets/cmd/pets@latest
+```
+
+`/pets-setup` checks for it first and prints those two lines rather than failing at
+you.

--- a/plugin/skills/pets-setup/SKILL.md
+++ b/plugin/skills/pets-setup/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: pets-setup
+description: "Wire pets into this machine's Claude Code config, or say how to install the binary. Use when the user types /pets-setup or asks to set pets up."
+allowed-tools: Bash(pets:*), Bash(command:*)
+---
+
+Run the installer and report what it wired:
+
+```sh
+command -v pets >/dev/null 2>&1 && pets install --harness=claude || echo "not-installed"
+```
+
+If that printed `not-installed`, the binary is missing. Do not try to install it
+yourself - print these two options and stop:
+
+```sh
+brew install TevvvB/tap/parallel-harness-pets
+go install github.com/TevvvB/parallel-harness-pets/cmd/pets@latest
+```
+
+Otherwise relay the installer's own output. It backs up any config it touches, and
+`pets uninstall` reverses it. Tell the user to start a new session, because Claude
+Code reads the status line and hooks at startup.

--- a/plugin/skills/pets/SKILL.md
+++ b/plugin/skills/pets/SKILL.md
@@ -20,9 +20,10 @@ The script prints a pre-formatted card with ANSI colours and box characters.
 the terminal renders the spacing. Do not summarise it, describe the creature in
 prose, add commentary, or strip escape codes.
 
-The creature is a pure function of the branch name, so it is not something the
-user picks or renames. If they ask why it changed, the answer is that the branch
-changed.
+`pets card` is typed by a person, so there is no agent session to key on and the
+creature comes from the branch. A live agent's status line keys on its session id
+instead, which is why one worktree can show several different creatures at once.
+Either way it is derived, never picked or renamed.
 
 If `$ARGUMENTS` is `why`, additionally name the signals shown in warning colour
 and, for each, the concrete command that clears it: `git commit` for


### PR DESCRIPTION
`/plugin marketplace add TevvvB/parallel-harness-pets` is a much lower-friction way
in than hearing about a `curl | sh` somewhere and going to a terminal. The plugin
marketplaces are also a directory ecosystem sitting in exactly this niche -
`obra/superpowers-marketplace` (1.2k★), `fivetaku/gptaku_plugins` (1k★),
`Piebald-AI/claude-code-lsps` (512★), `trailofbits/skills-curated` (488★) - all
GitHub repos taking submissions, so none of them gate on account age or karma. And
every one of them describes itself in productivity terms, which makes "fun" an
unoccupied category rather than a crowded one.

## What it ships

Two skills and no configuration:

| Skill | Does |
|---|---|
| `/pets` | Prints this worktree's card. |
| `/pets-setup` | Runs `pets install`, or says how to get the binary if it is missing. |

## Two things it deliberately does not do, both discovered by validating

**It does not declare `statusLine`.** I wrote it that way first, copying a published
plugin that does. `claude plugin validate` rejects it:

```
⚠ statusLine: Unknown field 'statusLine'. Claude Code ignores it at load time.
```

So a plugin cannot install a status line, and at least one plugin on a public
marketplace is shipping a field that silently does nothing. Worth knowing before
anyone else copies that pattern.

**It does not install the hooks either**, though a plugin can. `pets install`
already writes the status line and all three hooks, backs up what it touches and
reverses with `pets uninstall`. A plugin wiring the same three hooks would
double-fire them for anyone who had run the installer, and leave half behind when
either was removed. One owner for that configuration beats saving a step, so
`/pets-setup` is the seam instead.

The validator also caught `"shell": "sh"` in the hooks I initially wrote - only
`bash` and `powershell` are accepted. Moot now that the hooks are gone, but it is
why validating beat copying examples.

## Verified, not assumed

- `claude plugin validate ./plugin` and `claude plugin validate .` both pass.
- Installed it for real from a local path: marketplace added, `pets@parallel-harness-pets`
  installed and enabled at 0.2.2, and `claude plugin details` reports
  `Skills (2) pets, pets-setup` at ~76 always-on tokens. Then uninstalled and removed
  the marketplace, so my own config is back where it started.
- The first inventory read `Skills (2) pets, setup`, which is too generic a name to
  put in someone's global namespace, hence `pets-setup`.

## Also

`skill/SKILL.md` was referenced by nothing anywhere in the repo, so it moves into the
plugin where it is actually reachable. Its line about the creature being "a pure
function of the branch name" has only been true for `pets card` since v0.2.0, so it
now says which surface keys on what - the same rot as #20, but this copy is prose a
user reads.