### PR TITLE
Say that brew update comes first

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,14 @@ easier to keep straight, a star helps other people find it.
 
 | Installed with | Update with |
 |---|---|
-| Homebrew | `brew upgrade parallel-harness-pets` |
+| Homebrew | `brew update && brew upgrade parallel-harness-pets` |
 | The install script | re-run it, it replaces the binary in place |
 | Go | `go install github.com/TevvvB/parallel-harness-pets/cmd/pets@latest` |
 | A release archive | download the new one |
+
+`brew update` first is not optional. Without it Homebrew reads its cached copy of the
+tap and answers *"the latest version is already installed"* while installing the old
+one, which is worse than an error because nothing looks wrong.
 
 Homebrew refuses to upgrade a cask from a tap it does not trust, so the first
 upgrade may stop with *"Refusing to load cask ... from untrusted tap"*. Trust it


### PR DESCRIPTION
Found by upgrading for real rather than reading the table.

The tap regenerated itself to 0.2.3 and `brew upgrade parallel-harness-pets` answered *"Not upgrading, the latest version is already installed"* - while `pets version` still printed 0.2.2. Homebrew was reading its cached tap clone. `brew update` first, and the upgrade went through immediately.

This matters more than a normal doc nit because it fails **silently and positively**: someone who has just read release notes runs the documented command, is told they are current, and concludes the release never shipped.