### PR TITLE
Probe from the session-start hook, so a hook-only session appears in pets party

### DIFF
--- a/cmd/pets/collection.go
+++ b/cmd/pets/collection.go
@@ -126,6 +126,11 @@ func hatchCommand() {
 	}
 	// Ahead of the marker check, which returns for any worktree that hatched before.
 	registerAgent(cacheDir, repo, payload.agent(), time.Now())
+	// pets party lists worktrees that have state, and joins agents onto them, so
+	// registering without probing leaves a live session in the register and absent
+	// from the listing. Session start is also when fresh state is most wanted, and
+	// probe self-throttles behind a lock.
+	probe(repo.Root, settings)
 	marker := hatchMarker(cacheDir, repo.Key())
 	if _, err := os.Stat(marker); err == nil {
 		return


### PR DESCRIPTION
Fixes #29, the residual I found while testing #26's fix against the shipped binary.

#26 made every hook register the agent. But `pets party` iterates worktree **state** and
only joins the register *onto* it, and state is written by `probe`, which is reached from
`render` and from `quip`. So with hooks and no status line, a session was registered and
still absent from the listing until its first turn ended.

`hatch` now probes, placed ahead of the marker check for the same reason `registerAgent`
is: most session starts happen in a worktree that hatched long ago. Session start is also
when fresh state is most wanted, and `probe` self-throttles behind a lock, so this costs a
few git subprocesses once per session rather than per turn.

## Of the two options in #29, this is the first

The alternative was teaching `party` to surface dens known only from the register. That is
truer to the data model — an agent is live whether or not anyone probed its worktree — but
every column `party` prints today comes from state, so it is a rendering change rather than
a one-line fix. Worth doing on its own merits, not as a bug fix.

## No unit test, deliberately

`partyCommand` reads config and the state directory and prints, and a test against `probe`
alone would pass whether or not this call site exists. That is exactly the trap I fell into
in #30, where I wrote a test against `render.Residents` for a bug that lived in
`cardCommand` and deleted it after watching the suite stay green with the fix reverted.

Verified end to end instead, in a sandboxed `HOME`, both directions:

- Feed a hatch payload and nothing else - no render, no quip - and `pets party` prints
  `1 dens · 1 agent` with the session's name on the resident line.
- Remove this one call and the same sequence prints `(-.-) no worktrees seen yet. open one.`