### PR TITLE
Show each agent's context fill on its resident row

### DIFF
--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -108,6 +108,10 @@ type hookPayload struct {
 	Model struct {
 		DisplayName string `json:"display_name"`
 	} `json:"model"`
+	// The only genuinely per-agent signal here: mood comes from the worktree and is shared.
+	ContextWindow struct {
+		UsedPercentage int `json:"used_percentage"`
+	} `json:"context_window"`
 	ToolInput struct {
 		Command string `json:"command"`
 	} `json:"tool_input"`
@@ -123,6 +127,7 @@ type agent struct {
 	Repo      string
 	Worktree  string
 	Model     string
+	Context   int
 }
 
 func (p hookPayload) agent() agent {
@@ -132,6 +137,7 @@ func (p hookPayload) agent() agent {
 		Repo:      p.Workspace.Repo.Name,
 		Worktree:  p.Workspace.GitWorktree,
 		Model:     p.Model.DisplayName,
+		Context:   p.ContextWindow.UsedPercentage,
 	}
 }
 
@@ -209,6 +215,7 @@ func registerAgent(cacheDir string, repo gitrepo.Repo, who agent, now time.Time)
 		Root:    repo.Root,
 		Branch:  repo.Branch,
 		Name:    who.Name,
+		Context: who.Context,
 	}, now)
 	// Touch forgets an agent the moment it moves; the visit log is the half that does not.
 	visits.Record(cacheDir, den, who.SessionID, now)

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -51,6 +51,8 @@ type Record struct {
 	// Since says how long it has been here, which is a different question once
 	// an agent can move between worktrees.
 	Since time.Time
+	// Context is the context window's fill percentage; zero means unknown, since only the status line reports it.
+	Context int
 }
 
 func (r Record) Stale(now time.Time) bool { return now.Sub(r.Seen) >= StaleAfter }
@@ -100,6 +102,10 @@ func Touch(stateDir string, record Record, now time.Time) error {
 	path := filepath.Join(dir(stateDir), fileName(record.Session))
 	record.Since = now
 	if existing, err := read(path); err == nil {
+		// A hook carries no context window, and must not reset what the status line knew.
+		if record.Context == 0 {
+			record.Context = existing.Context
+		}
 		if existing.Den == record.Den {
 			// Same den, so the arrival time carries over rather than being reset
 			// by every heartbeat.
@@ -116,10 +122,11 @@ func Touch(stateDir string, record Record, now time.Time) error {
 	}
 	record.Seen = now
 	var out strings.Builder
-	fmt.Fprintf(&out, "session=%s\nden=%s\nroot=%s\nbranch=%s\nname=%s\nts=%d\nsince=%d\n",
+	fmt.Fprintf(&out, "session=%s\nden=%s\nroot=%s\nbranch=%s\nname=%s\nts=%d\nsince=%d\ncontext=%d\n",
 		record.Session, record.Den, record.Root, record.Branch,
 		// A newline in a session name would forge a second field on read.
-		strings.ReplaceAll(record.Name, "\n", " "), record.Seen.Unix(), record.Since.Unix())
+		strings.ReplaceAll(record.Name, "\n", " "), record.Seen.Unix(), record.Since.Unix(),
+		record.Context)
 	temporary := path + ".tmp"
 	if err := os.WriteFile(temporary, []byte(out.String()), 0o644); err != nil {
 		return err
@@ -174,6 +181,12 @@ func read(path string) (Record, error) {
 				return Record{}, err
 			}
 			record.Seen = time.Unix(seconds, 0)
+		case "context":
+			percent, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil {
+				return Record{}, err
+			}
+			record.Context = percent
 		case "since":
 			seconds, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
 			if err != nil {

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -144,3 +144,28 @@ func TestLabelFallsBackToTheSessionID(t *testing.T) {
 		t.Errorf("unnamed session labelled %q", unnamed)
 	}
 }
+
+// Only the status line payload carries a context window. A hook firing between two
+// status line ticks passes zero, and must not overwrite what the status line knew.
+func TestTouchKeepsAKnownContextWhenAHookReportsNone(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	record := Record{Session: "ctx-session", Den: "place:one#one", Context: 72}
+	if err := Touch(dir, record, now); err != nil {
+		t.Fatal(err)
+	}
+
+	// Past the heartbeat, so the write is not throttled, and with no context.
+	later := now.Add(2 * Heartbeat)
+	if err := Touch(dir, Record{Session: "ctx-session", Den: "place:one#one"}, later); err != nil {
+		t.Fatal(err)
+	}
+
+	live := All(dir, later)
+	if len(live) != 1 {
+		t.Fatalf("register holds %d agents, want 1", len(live))
+	}
+	if live[0].Context != 72 {
+		t.Errorf("context is %d after a hook reported none, want 72 preserved", live[0].Context)
+	}
+}

--- a/internal/render/collection.go
+++ b/internal/render/collection.go
@@ -133,9 +133,10 @@ func Party(views []View, settings config.Config, showAll bool, now time.Time) st
 			if alone {
 				creature, species = pad("", 9), pad("", 8)
 			}
-			fmt.Fprintf(&out, "       %s%s %s%s  %s%s%s%s\n",
+			fmt.Fprintf(&out, "       %s%s %s%s  %s%s%s%s%s\n",
 				tone, creature, species, reset,
-				dim, pad(truncate(resident.Label(), 36), 38), since(resident.Seen, now), note)
+				dim, pad(truncate(resident.Label(), 36), 38), since(resident.Seen, now), note,
+				contextNote(resident.Context))
 		}
 	}
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -247,6 +247,21 @@ func since(then, now time.Time) string {
 //
 // This is the view the old model could not express: a worktree held one
 // creature, so a second agent in the same worktree was invisible.
+// ContextFull is where the figure stops being dim and starts warning: an agent near the end of its window is actionable.
+const ContextFull = 80
+
+// contextNote renders the fill, or nothing when unknown, so a hook-only harness is never shown a confident 0%.
+func contextNote(percent int) string {
+	if percent <= 0 {
+		return ""
+	}
+	tone := dim
+	if percent >= ContextFull {
+		tone = warn
+	}
+	return fmt.Sprintf(" %s· %d%%%s", tone, percent, reset)
+}
+
 func Residents(v View, now time.Time) string {
 	if len(v.Residents) == 0 {
 		return ""
@@ -286,10 +301,11 @@ func Residents(v View, now time.Time) string {
 		} else if resident.JustArrived(now) {
 			note = dim + "  just arrived" + reset
 		}
-		fmt.Fprintf(&out, "  %s%s%s%s  %s%s%s  %s%s%s%s\n",
+		fmt.Fprintf(&out, "  %s%s%s%s  %s%s%s  %s%s%s%s%s\n",
 			marker, tone, pad(body, width), reset,
 			tone, pad(pet.Name, 9), reset,
-			dim, pad(truncate(resident.Label(), 32), 34), since(resident.Seen, now), note)
+			dim, pad(truncate(resident.Label(), 32), 34), since(resident.Seen, now), note,
+			contextNote(resident.Context))
 	}
 	return out.String()
 }


### PR DESCRIPTION
`IDEAS.md` called `context_window.used_percentage` the strongest of the unused payload
signals, and gave the reason: mood comes from the worktree and every resident of a den
shares it, so **context fill is the only thing the model can say about one agent rather
than one directory**. A den of agents at 90% reads very differently from one at 10%, and
nothing could tell you which.

```
  @CAI <[•ᴗ•]>   ray ✦✦✦   feat/context-demo  ♥♥♥♥♥
       <[•ᴗ•]>   ray       Early in the turn      just now · just arrived · 22%
       /•ᴗ•\     cat       Nearly out of room     just now · just arrived · 91%
```

Dim below 80%, warning at or above it, since an agent about to run out of window is the
one thing on that row you might act on before it does. Both `pets party` and `pets card`
share one helper so they cannot drift about the threshold.

## Two decisions worth stating

**Not a face change.** IDEAS suggested a pet that gets visibly sleepy. The face is driven
by mood, mood is per-worktree, and overloading it would undo exactly the separation the
v0.2.0 rewrite existed to create. Getting the per-agent data recorded and visible first
also leaves that option open on evidence rather than on a hunch.

**Zero means unknown, not empty.** Only the status line payload carries a context window,
so a hook-only harness has no figure and must not be shown a confident `0%`.

## The one test

That last point is also the one plausible bug: hooks pass no context, and a hook firing
between two status line ticks would reset a known percentage to unknown. `Touch` keeps the
existing value when the incoming one is zero, and the test fails with
`context is 0 after a hook reported none, want 72 preserved` if that guard is removed - I
checked by removing it.

Verified end to end too, in a sandboxed `HOME`: two sessions in one den at 22% and 91%,
and the rendered output confirmed `22% -> dim` and `91% -> warn` by parsing the escape
codes rather than eyeballing them.