### PR TITLE
Bump the plugin to 0.2.5, and stop the version drifting silently

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A creature for every agent session, living in your status line",
-    "version": "0.2.2"
+    "version": "0.2.5"
   },
   "plugins": [
     {
       "name": "pets",
       "source": "./plugin",
       "description": "The /pets skill plus a one-command setup. Gives every agent session its own creature in the status line, with a den per git worktree, rarity bands and 16 cities to collect.",
-      "version": "0.2.2",
+      "version": "0.2.5",
       "category": "fun",
       "keywords": [
         "statusline",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,28 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
+      # The plugin carries its own version, and Claude Code only offers an update when
+      # that field changes -- so drifting it silently pins every plugin user. It drifted
+      # three releases before anyone noticed, hence a gate rather than a habit.
+      - name: plugin manifests match the tag
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          for file in plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json; do
+            while read -r found; do
+              if [ "$found" != "$tag" ]; then
+                echo "::error file=$file::version $found does not match tag $tag"
+                exit 1
+              fi
+            done < <(python3 -c "
+          import json, sys
+          data = json.load(open(sys.argv[1]))
+          print(data.get('version', ''))
+          for plugin in data.get('plugins', []):
+              print(plugin.get('version', ''))
+          " "$file" | grep -v '^$')
+          done
+          echo "plugin manifests agree with $tag"
+
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: "~> v2"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,19 @@
 # Releasing
 
+First bump the plugin's version in both manifests, then tag:
+
 ```sh
+# plugin/.claude-plugin/plugin.json and .claude-plugin/marketplace.json (two places in that one)
 git tag -a vX.Y.Z -m "…" && git push origin vX.Y.Z
 ```
 
-That is the whole thing. The release workflow builds every platform and
-publishes the archives and checksums.
+The release workflow builds every platform and publishes the archives and checksums.
+
+**The plugin bump is not optional and the workflow enforces it.** Claude Code only offers
+an update when `plugin.json`'s `version` changes, so leaving it behind pins every plugin
+user on whatever they installed. It drifted three releases before anyone noticed, so the
+release now fails on a mismatch rather than trusting the habit. If it fails, fix the
+manifests, delete the tag, and tag again.
 
 ## The Homebrew cask updates itself
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pets",
-  "version": "0.2.2",
+  "version": "0.2.5",
   "description": "A creature for every agent session, in a den for every git worktree. Its mood tracks how tidy that worktree is, so several agents at once stay tellable apart at a glance.",
   "author": {
     "name": "TevvvB",


### PR DESCRIPTION
The plugin manifests said **0.2.2** while the project was at **v0.2.5**.

That is not cosmetic. From the plugin docs: *"If set, users only receive updates when you
bump this field."* So everyone who installed the plugin was **pinned on 0.2.2** and would
never be offered anything newer, including the two bug fixes and the feature shipped since.

## Why nothing caught it

- `claude plugin validate --strict` passes happily. It validates schema, not agreement with
  the project.
- `claude plugin tag` does check versions - but it checks `plugin.json` against the enclosing
  **marketplace entry**. Those two agreed with each other the whole time. It is a different
  invariant from the one that broke.

Nothing anywhere related the plugin's version to the release it ships alongside, and the
version is duplicated in three places, so drift was a matter of time rather than an accident.

## The fix

Both manifests go to 0.2.5, and the release workflow now **fails if they disagree with the
tag being released**, with a file annotation pointing at the offender. Tested both ways: it
passes on `v0.2.5` and fails on `v0.9.9`.

`RELEASING.md` also stops saying the tag "is the whole thing", because it no longer is - it
now names the bump as a step and says what to do when the gate fires (fix, delete the tag,
tag again).

I considered dropping the `version` field instead, since the docs make it optional, but an
explicit version is worth more to someone browsing a marketplace than the duplication costs
now that it is enforced rather than remembered.