### PR TITLE
Keep the Codex hooks silent, because Codex reads what they print

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ nothing on the status line path touches the network. Turn it off with
 | Agent | What you get |
 |---|---|
 | Claude Code | Full: live status line, hatch, quips |
-| Codex CLI | Hooks are written, but untested against a real Codex. Use the shell snippet below for the pet itself |
+| Codex CLI | Hooks are wired and now stay silent on purpose - see below. Use the shell snippet for the pet itself |
 | tmux or your shell prompt | Full pet, works with **any** agent |
 | Editors | `pets render --format=json` to build your own |
 
@@ -131,6 +131,14 @@ Amp, Gemini CLI, or anything else. `pets install` prints the snippets.
 
 Claude Code is the only agent this has been verified against end to end. If you
 run something else and it works, or does not, please open an issue.
+
+**Why the Codex hooks print nothing.** A Codex user reported that Codex reads a hook's
+response and that a malformed one can stop the turn before it starts, while still exiting
+zero - so it looks like a hang rather than an error. Claude Code simply displays whatever a
+hook prints, so the same output is safe there and risky here. Until that response format is
+confirmed, `pets install --harness=codex` wires the hooks with `--harness=codex` and they
+write nothing at all. They still record everything, so `pets den` and `pets party` fill up
+normally; you just do not get the hatch card or the quip.
 
 ## Reading it
 

--- a/cmd/pets/collection.go
+++ b/cmd/pets/collection.go
@@ -113,7 +113,7 @@ func hatchMarker(cacheDir, key string) string {
 }
 
 // hatchCommand runs on SessionStart. It is the only animated moment in the tool.
-func hatchCommand() {
+func hatchCommand(args []string) {
 	settings := config.Load()
 	payload := readPayload()
 	repo, found := gitrepo.Locate(payload.directory())
@@ -144,6 +144,9 @@ func hatchCommand() {
 	// checkout -b loop farms the collection.
 	recordIfEarned(repo, settings, cacheDir)
 
+	if speechless(args) {
+		return
+	}
 	pet := identity.For(repo.Branch)
 	collection := den.Load(cacheDir)
 	fmt.Print(render.Hatch(pet, collection.Distinct(), len(identity.All()), collection.Has(pet)))

--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -70,11 +70,11 @@ func dispatch(args []string) int {
 	case "probe":
 		probeCommand(args[1:])
 	case "hatch":
-		hatchCommand()
+		hatchCommand(args[1:])
 	case "record":
 		recordCommand()
 	case "quip":
-		quipCommand()
+		quipCommand(args[1:])
 	case "install", "uninstall":
 		installCommand(args[0], args[1:])
 	case "version", "--version", "-v":
@@ -278,6 +278,12 @@ func refreshInBackground(root string) {
 	}
 }
 
+// speechless reports a harness whose hook stdout we should not write to. Codex parses a
+// hook's response and a malformed one can silently stop the turn; Claude Code just shows it.
+func speechless(args []string) bool {
+	return flagValue(args, "harness", "") == "codex"
+}
+
 func flagValue(args []string, name, fallback string) string {
 	for _, arg := range args {
 		if value, found := stringsCutPrefix(arg, "--"+name+"="); found {
@@ -459,7 +465,7 @@ func responseText(raw json.RawMessage) string {
 	return string(raw)
 }
 
-func quipCommand() {
+func quipCommand(args []string) {
 	settings := config.Load()
 	payload := readPayload()
 	repo, found := gitrepo.Locate(payload.directory())
@@ -471,6 +477,9 @@ func quipCommand() {
 	probe(repo.Root, settings)
 	view, ok := build(repo.Root, payload.agent(), settings)
 	if !ok {
+		return
+	}
+	if speechless(args) {
 		return
 	}
 	message := fmt.Sprintf("%s %s: %s", view.Body(), view.Pet.Name, quipFor(view))

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -187,8 +187,8 @@ func InstallCodex(binary string, remove bool) error {
 		setHook(settings, "SessionStart", "", "")
 	} else {
 		setHook(settings, "PostToolUse", binary+" record", "Bash")
-		setHook(settings, "Stop", binary+" quip", "")
-		setHook(settings, "SessionStart", binary+" hatch", "")
+		setHook(settings, "Stop", binary+" quip --harness=codex", "")
+		setHook(settings, "SessionStart", binary+" hatch --harness=codex", "")
 	}
 	return saveJSON(path, settings)
 }


### PR DESCRIPTION
I posted on openai/codex asking whether the hooks pets installs actually fire. A Codex user
answered with something better than the question deserved: **Codex reads a hook's response**,
a malformed one can stop the turn before it begins, and **it still exits zero** - so the
symptom is a hang rather than an error.

That reframes this from "my Codex support might do nothing" to "my Codex support might break
your session".

## What pets was writing into that slot

Going and looking:

| Hook | stdout |
|---|---|
| `SessionStart` (`hatch`) | a block of **ASCII art**, on the first sight of a worktree |
| `Stop` (`quip`) | `{"systemMessage": "..."}` - Claude Code's shape |
| `PostToolUse` (`record`) | nothing |

Claude Code just displays whatever a hook prints, so both are fine there. If Codex parses
them, the failing case is **somebody's first session in a new worktree** - the worst possible
one to break.

## The change

`pets install --harness=codex` now wires the hooks as `pets hatch --harness=codex` and
`pets quip --harness=codex`, and those paths write nothing. The Claude Code install is
untouched and still prints both.

Silence is not inaction: everything is still recorded, so `pets den` and `pets party` fill up
normally. You lose the hatch card and the quip, which is the right trade against possibly
stopping a turn.

`ours()` still matches the flagged commands, so `pets uninstall` keeps working. Existing
installs keep the unflagged commands until `pets install` is re-run, which replaces its own
entries.

## No unit test, and the risk that leaves

`hatchCommand` and `quipCommand` read config, locate a repo and print, so the assertion that
matters is not reachable from a unit test - and a test against the flag helper would pass
whether or not the guard sits in the right *place*. The plausible refactor mistake here is
moving the guard above the registration, making the Codex path silent **and** useless, and no
test I can cheaply write would catch that.

So it is verified in a sandbox, both directions:

- `hatch --harness=codex` writes **0 bytes** and the agent is still registered and the
  worktree probed - `pets party` shows `1 dens · 1 agent` with the session name.
- unflagged `hatch` still writes its 356-byte card.

README's Codex row was stale as written and now explains the reasoning rather than just
claiming "untested". Refs #15.