### PR TITLE
Bump the plugin to 0.2.6 ahead of the tag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A creature for every agent session, living in your status line",
-    "version": "0.2.5"
+    "version": "0.2.6"
   },
   "plugins": [
     {
       "name": "pets",
       "source": "./plugin",
       "description": "The /pets skill plus a one-command setup. Gives every agent session its own creature in the status line, with a den per git worktree, rarity bands and 16 cities to collect.",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "category": "fun",
       "keywords": [
         "statusline",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pets",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A creature for every agent session, in a den for every git worktree. Its mood tracks how tidy that worktree is, so several agents at once stay tellable apart at a glance.",
   "author": {
     "name": "TevvvB",


### PR DESCRIPTION
Required by the gate added in #37: the release workflow fails if the plugin manifests disagree with the tag. First time it has actually changed the process, which is the point of it.