### PR TITLE
Codex hooks were never trusted, which is why they never ran

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ nothing on the status line path touches the network. Turn it off with
 | Agent | What you get |
 |---|---|
 | Claude Code | Full: live status line, hatch, quips |
-| Codex CLI | Hooks are wired and now stay silent on purpose - see below. Use the shell snippet for the pet itself |
+| Codex CLI | Hooks work, but Codex must trust them first - see below. No status line there, so use the shell snippet for the pet |
 | tmux or your shell prompt | Full pet, works with **any** agent |
 | Editors | `pets render --format=json` to build your own |
 
@@ -132,13 +132,16 @@ Amp, Gemini CLI, or anything else. `pets install` prints the snippets.
 Claude Code is the only agent this has been verified against end to end. If you
 run something else and it works, or does not, please open an issue.
 
-**Why the Codex hooks print nothing.** A Codex user reported that Codex reads a hook's
-response and that a malformed one can stop the turn before it starts, while still exiting
-zero - so it looks like a hang rather than an error. Claude Code simply displays whatever a
-hook prints, so the same output is safe there and risky here. Until that response format is
-confirmed, `pets install --harness=codex` wires the hooks with `--harness=codex` and they
-write nothing at all. They still record everything, so `pets den` and `pets party` fill up
-normally; you just do not get the hatch card or the quip.
+**Codex hooks have to be trusted before they run.** This is the thing to know, and nothing
+tells you: Codex will not execute a new or changed hook until you accept it, an untrusted hook
+is completely silent, and `codex doctor` does not mention hooks at all. So a fresh
+`pets install --harness=codex` looks like it worked and does nothing until you say yes on the
+next session start. Verified on Codex 0.149.0 - the same config fires only when run with
+`--dangerously-bypass-hook-trust`.
+
+Once trusted it works: Codex's payloads carry `session_id`, which is what a creature is keyed
+on, so agents register and `pets den` and `pets party` fill up as they do under Claude Code.
+There is no `workspace` object in a Codex payload, so the den name comes from git instead.
 
 ## Reading it
 

--- a/cmd/pets/collection.go
+++ b/cmd/pets/collection.go
@@ -113,7 +113,7 @@ func hatchMarker(cacheDir, key string) string {
 }
 
 // hatchCommand runs on SessionStart. It is the only animated moment in the tool.
-func hatchCommand(args []string) {
+func hatchCommand() {
 	settings := config.Load()
 	payload := readPayload()
 	repo, found := gitrepo.Locate(payload.directory())
@@ -144,9 +144,6 @@ func hatchCommand(args []string) {
 	// checkout -b loop farms the collection.
 	recordIfEarned(repo, settings, cacheDir)
 
-	if speechless(args) {
-		return
-	}
 	pet := identity.For(repo.Branch)
 	collection := den.Load(cacheDir)
 	fmt.Print(render.Hatch(pet, collection.Distinct(), len(identity.All()), collection.Has(pet)))

--- a/cmd/pets/install.go
+++ b/cmd/pets/install.go
@@ -48,6 +48,19 @@ func installCommand(action string, args []string) {
 		return
 	}
 
+	// Codex will not run a new or changed hook until it has been trusted, and nothing
+	// anywhere says so -- an untrusted hook is silent, and `codex doctor` does not mention
+	// hooks at all. Verified on 0.149.0: identical config fires only with
+	// --dangerously-bypass-hook-trust.
+	for _, target := range targets {
+		if target != harness.Codex {
+			continue
+		}
+		fmt.Println("\nCodex will not run these until it trusts them. It asks on the next")
+		fmt.Println("session start after a hook changes. Until you accept, they do nothing")
+		fmt.Println("and nothing tells you so.")
+	}
+
 	// The snippets are configuration, and ending on them leaves somebody with
 	// nothing to try. One creature in one repo is also not the point, so send
 	// them to a second worktree, which is where this stops looking like a

--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -70,11 +70,11 @@ func dispatch(args []string) int {
 	case "probe":
 		probeCommand(args[1:])
 	case "hatch":
-		hatchCommand(args[1:])
+		hatchCommand()
 	case "record":
 		recordCommand()
 	case "quip":
-		quipCommand(args[1:])
+		quipCommand()
 	case "install", "uninstall":
 		installCommand(args[0], args[1:])
 	case "version", "--version", "-v":
@@ -278,12 +278,6 @@ func refreshInBackground(root string) {
 	}
 }
 
-// speechless reports a harness whose hook stdout we should not write to. Codex parses a
-// hook's response and a malformed one can silently stop the turn; Claude Code just shows it.
-func speechless(args []string) bool {
-	return flagValue(args, "harness", "") == "codex"
-}
-
 func flagValue(args []string, name, fallback string) string {
 	for _, arg := range args {
 		if value, found := stringsCutPrefix(arg, "--"+name+"="); found {
@@ -465,7 +459,7 @@ func responseText(raw json.RawMessage) string {
 	return string(raw)
 }
 
-func quipCommand(args []string) {
+func quipCommand() {
 	settings := config.Load()
 	payload := readPayload()
 	repo, found := gitrepo.Locate(payload.directory())
@@ -477,9 +471,6 @@ func quipCommand(args []string) {
 	probe(repo.Root, settings)
 	view, ok := build(repo.Root, payload.agent(), settings)
 	if !ok {
-		return
-	}
-	if speechless(args) {
 		return
 	}
 	message := fmt.Sprintf("%s %s: %s", view.Body(), view.Pet.Name, quipFor(view))

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -187,8 +187,8 @@ func InstallCodex(binary string, remove bool) error {
 		setHook(settings, "SessionStart", "", "")
 	} else {
 		setHook(settings, "PostToolUse", binary+" record", "Bash")
-		setHook(settings, "Stop", binary+" quip --harness=codex", "")
-		setHook(settings, "SessionStart", binary+" hatch --harness=codex", "")
+		setHook(settings, "Stop", binary+" quip", "")
+		setHook(settings, "SessionStart", binary+" hatch", "")
 	}
 	return saveJSON(path, settings)
 }


### PR DESCRIPTION
Tested against a real Codex **0.149.0** instead of reasoning about it, and the result inverts
#38.

## The actual bug

**Codex will not run a new or changed hook until it has been trusted.** An untrusted hook is
completely silent, and `codex doctor` does not mention hooks at all, so `pets install
--harness=codex` looked like it worked and did nothing. Same config, same binary, one flag
apart:

```
codex exec "..."                                    # nothing fires
codex exec --dangerously-bypass-hook-trust "..."    # SessionStart and Stop both fire
```

That explains the whole mystery. The hooks had been sitting in `~/.codex/hooks.json` since
11 August and had never once executed. Nothing was wrong with them.

The fix is the installer saying so, which it now does - and only for Codex.

## #38 was guarding against a risk that is not real, so it is reverted

v0.2.6 silenced the Codex hooks on the theory that Codex parses a hook's stdout and a
malformed response could stop the turn. Tested: **it does not.** A `SessionStart` hook printing
a block of ASCII art completed the turn normally.

Two supporting details: the only invalid-JSON error in the binary is scoped to `PreToolUse`,
and `systemMessage` is part of Codex's own hook output schema alongside `additionalContext`
and `stopReason` - so `quip`'s Claude-shaped JSON was valid there all along. Silencing removed
working output for nothing, so both hooks speak again.

## What does work, verified end to end

Codex's payloads carry **`session_id`**, which is what a creature is keyed on:

- `SessionStart`: `cwd, hook_event_name, model, permission_mode, session_id, source, transcript_path`
- `Stop`, additionally: `last_assistant_message, stop_hook_active, turn_id`

pets registered the real Codex session as
`01a02fa5-729d-7d10-a11c-c7d732067e27.agent`. There is no `workspace` object, so the den name
falls back to git - which the existing fallback already handles.

The findings are written up on
[openai/codex#40034](https://github.com/openai/codex/discussions/40034), where I had asked the
question; that comment now carries answers and the payload shapes rather than questions.