### PR TITLE
Pin the Codex payload shape with a captured fixture

### DIFF
--- a/cmd/pets/replay_test.go
+++ b/cmd/pets/replay_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/TevvvB/parallel-harness-pets/internal/agents"
 	"github.com/TevvvB/parallel-harness-pets/internal/gitrepo"
+	"github.com/TevvvB/parallel-harness-pets/internal/identity"
 	"github.com/TevvvB/parallel-harness-pets/internal/state"
 )
 
@@ -135,5 +136,47 @@ func TestRecordFromRegistersTheAgentEvenWhenTheCommandIsNotATestRun(t *testing.T
 	}
 	if live[0].Den == "" {
 		t.Error("agent registered with no den, so no listing can group it")
+	}
+}
+
+// Codex is the reason parsePayload must not treat a decode error as fatal.
+//
+// Its payload sends model as a plain string where Claude Code sends an object,
+// so unmarshalling it always returns an UnmarshalTypeError. Go fills in every
+// other field regardless, which is the only reason Codex works at all. Add the
+// error check that line looks like it is missing and every Codex hook stops
+// registering agents, with the whole Claude Code suite still green.
+//
+// Codex also sends no workspace object, so the den has to come from git. A
+// registerAgent that trusted the payload's worktree would put every checkout
+// in one shared den, and again only Codex would notice.
+func TestCapturedCodexPayloadRegistersIntoTheGitDerivedDen(t *testing.T) {
+	root := worktree(t, "feat-example")
+	cache := t.TempDir()
+	now := time.Now()
+
+	payload := parsePayload(strings.NewReader(fixture(t, "codex-sessionstart.json", root)), time.Second)
+	if payload.SessionID == "" {
+		t.Fatal("no session_id survived the decode: every Codex hook is anonymous")
+	}
+	if payload.Workspace.GitWorktree != "" {
+		t.Fatal("fixture has a workspace object, so it no longer exercises the git fallback")
+	}
+
+	located, found := gitrepo.Locate(root)
+	if !found {
+		t.Fatalf("could not locate the worktree at %s", root)
+	}
+	den := registerAgent(cache, located, payload.agent(), now)
+	if want := identity.DenKey(located.Project(), located.Worktree()); den != want {
+		t.Errorf("den %q, want the git-derived %q", den, want)
+	}
+
+	residents := agents.InDen(cache, den, now)
+	if len(residents) != 1 {
+		t.Fatalf("den holds %d agents after one Codex hook, want 1", len(residents))
+	}
+	if residents[0].Session != payload.SessionID {
+		t.Errorf("den holds session %q, want %q", residents[0].Session, payload.SessionID)
 	}
 }

--- a/cmd/pets/testdata/codex-sessionstart.json
+++ b/cmd/pets/testdata/codex-sessionstart.json
@@ -1,0 +1,9 @@
+{
+  "cwd": "/home/user/code/demo/.worktrees/feat-example",
+  "hook_event_name": "SessionStart",
+  "model": "gpt-5.6-sol",
+  "permission_mode": "bypassPermissions",
+  "session_id": "00000000-0000-0000-0000-000000000000",
+  "source": "startup",
+  "transcript_path": "/home/user/.codex/sessions/2026/08/23/rollout-2026-08-23T13-22-47-00000000-0000-0000-0000-000000000000.jsonl"
+}


### PR DESCRIPTION
Closes #14.

## The bug this exists to catch

Codex sends `model` as a plain string where Claude Code sends an object:

```json
"model": "gpt-5.6-sol"          // Codex
"model": { "display_name": … }  // Claude Code
```

So `json.Unmarshal` on a Codex payload **always** returns an `UnmarshalTypeError`. Go populates every other field anyway, and `parsePayload` discards the error - which is the only reason Codex hooks work at all.

That makes this cleanup, which reads as ordinary hygiene, catastrophic:

```go
if err := json.Unmarshal(data, &payload); err != nil {
    return hookPayload{}
}
```

Every Codex hook silently stops registering its agent. Nothing tells you. The entire Claude Code suite stays green, because every other fixture sends `model` as an object.

Codex also sends no `workspace` object at all, so the den has to come from git. A `registerAgent` that trusted `who.Worktree` would put every checkout of a project into one shared den, and again only Codex would notice.

## Why a captured fixture

A hand-written fixture would have used an object for `model` - encoding the exact mistake the test is meant to catch. These are real bytes off a real `SessionStart`, sanitised per CONTRIBUTING (paths, username, session id, assistant message).

## Verified by mutation

Not "it passes". I injected both bugs and confirmed this is the **only** test in the repo that fails for either:

| Mutation | Tests that fail |
|---|---|
| the `err != nil` check above | this one, alone |
| `registerAgent` drops the git worktree fallback | this one, alone |

Both restored; full suite green, `gofmt` and `go vet` clean.

## Scope

One test, 43 lines, one fixture. I also captured a `Stop` payload and **deleted** it: the Stop path reads the same three fields (`directory()`, `SessionID`, `agent()`) and nothing from `turn_id`, `stop_hook_active`, or `last_assistant_message`, so it would exercise identical lines. Noted on #14 rather than shipped as dead testdata.