### PR TITLE
Document the identity model the callers actually use

### DIFF
--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -1,8 +1,13 @@
-// Package identity derives a worktree's creature from its branch name alone.
+// Package identity derives a creature from one opaque key.
 //
-// Nothing here touches disk or network: the same branch yields the same creature
-// on every machine, forever, with nothing persisted. Rarity is a weighted band
-// over the same hash, so a collection costs no extra state.
+// Nothing here touches disk or network: the same key yields the same creature on
+// every machine, forever, with nothing persisted. Rarity is a weighted band over
+// the same hash, so a collection costs no extra state.
+//
+// Callers decide what the key means, and they deliberately disagree. Live
+// surfaces pass a session id, so every agent gets its own creature. The den
+// passes a branch, so a creature is earned once per branch however many agents
+// pass through it.
 package identity
 
 import "fmt"
@@ -36,7 +41,7 @@ func (r Rarity) Stars() string {
 }
 
 // weights are per ten-thousand so the table stays exact in integer maths.
-// Tuned so a legendary lands roughly one branch in thirty.
+// Tuned so a legendary lands roughly one key in thirty.
 var weights = [...]int{6000, 2500, 1100, 350, 50}
 
 // Species is one creature: a name, its band, and the frame fragments bracketing its face.
@@ -106,7 +111,7 @@ var byRarity = func() map[Rarity][]Species {
 }()
 
 // Common and uncommon creatures take a hue hashed independently of species, so
-// two live branches on the same creature still read apart. The colours reserved
+// two live agents on the same creature still read apart. The colours reserved
 // for the higher bands are deliberately absent here, so an ordinary creature can
 // never be mistaken for a rare one.
 var palette = []int{173, 208, 114, 203, 187, 218, 79, 179, 156}
@@ -169,24 +174,24 @@ func bandFor(roll int) Rarity {
 	return Common
 }
 
-// For returns the creature belonging to a branch.
+// For returns the creature belonging to a key: a session id, a branch, anything stable.
 //
 // The band is chosen first so rarity stays on its intended distribution no
 // matter how many creatures a pack adds to any one band.
-func For(branch string) Pet {
-	band := bandFor(Hash("band:" + branch))
+func For(key string) Pet {
+	band := bandFor(Hash("band:" + key))
 	pool := byRarity[band]
 	if len(pool) == 0 {
 		pool = byRarity[Common]
 	}
 	color, reserved := bandColor[band]
 	if !reserved {
-		color = palette[Hash("hue:"+branch)%len(palette)]
+		color = palette[Hash("hue:"+key)%len(palette)]
 	}
 	return Pet{
-		Species: pool[Hash(branch)%len(pool)],
+		Species: pool[Hash(key)%len(pool)],
 		Color:   color,
-		Shiny:   Hash("shiny:"+branch)%shinyOdds == 0,
+		Shiny:   Hash("shiny:"+key)%shinyOdds == 0,
 	}
 }
 

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -10,7 +10,7 @@ import (
 // wearing their band. This table exists so neither changes again by accident.
 func TestForIsPinned(t *testing.T) {
 	cases := []struct {
-		branch  string
+		key     string
 		species string
 		color   int
 		rarity  Rarity
@@ -32,11 +32,11 @@ func TestForIsPinned(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		pet := For(testCase.branch)
+		pet := For(testCase.key)
 		if pet.Name != testCase.species || pet.Color != testCase.color ||
 			pet.Rarity != testCase.rarity || pet.Shiny != testCase.shiny {
 			t.Errorf("For(%q) = %s/%d/%s/shiny=%v, want %s/%d/%s/shiny=%v",
-				testCase.branch, pet.Name, pet.Color, pet.Rarity, pet.Shiny,
+				testCase.key, pet.Name, pet.Color, pet.Rarity, pet.Shiny,
 				testCase.species, testCase.color, testCase.rarity, testCase.shiny)
 		}
 	}
@@ -150,7 +150,7 @@ func TestHashIsStable(t *testing.T) {
 
 // Rarity has to be visible without decoding a star count, so anything rare or
 // above wears its band's colour. Commons and uncommons keep an independent hue,
-// which is what stops two live branches on the same creature reading alike.
+// which is what stops two live agents on the same creature reading alike.
 func TestRareCreaturesWearTheirBand(t *testing.T) {
 	bands := map[Rarity]int{}
 	ordinary := map[int]bool{}
@@ -171,6 +171,6 @@ func TestRareCreaturesWearTheirBand(t *testing.T) {
 		}
 	}
 	if len(ordinary) < 5 {
-		t.Errorf("only %d hues left for common and uncommon, too few to tell branches apart", len(ordinary))
+		t.Errorf("only %d hues left for common and uncommon, too few to tell agents apart", len(ordinary))
 	}
 }


### PR DESCRIPTION
Closes #20.

## Why the obvious fix was wrong

#20 says the parameter is named `branch` but receives session ids. True, but renaming it to `session` would have made the docs wrong in a *new* way, because two call sites genuinely pass a branch:

| Call site | Key | Consequence |
|---|---|---|
| `render.go`, `collection.go` resident rows, `main.go` | `resident.Session` | every agent gets its own creature |
| `collection.go:147`, `recordIfEarned` | `repo.Branch` | a creature is earned **once per branch**, however many agents pass through it |

That second row is deliberate - it's the thing that stops a session-spawn loop farming the den, and it's the substance of discussion #19. So the honest model is that the key is **opaque and the caller decides what identity means**, which is what the package doc now says.

This is also why I don't think it was a good first issue, and I've unlabelled it as one: following the issue literally produces a regression in the docs, and spotting that needs the whole call graph.

## The number was fine

The weights comment read "a legendary lands roughly one branch in thirty". I checked rather than assuming, because a false number is worse than a stale noun:

```
Common 6000  Uncommon 2500  Rare 1100  Legendary 350  Mythic 50   (per ten-thousand)
```

`Legendary` is band **3**, at 350/10000 ≈ 3.5% ≈ one in 28. Correct. `Mythic` is the 0.5% tier above it. Only the noun changed.

## Scope

Package doc, the `branch` → `key` parameter rename, and three comments that had become false statements about the model (including one in the test file: "two live *branches* on the same creature"). No behaviour change - pure renames and prose, full suite green.

`place.go`'s "deliberately not the branch" comments are correct as written and untouched. So are two test inputs that really are branch-shaped strings.