### PR TITLE
Say what adding a creature actually costs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,38 @@ one rarer to draw.
 Please check your creature reads at a glance in a terminal, not just in a diff.
 Faces range from `•ᴗ•` down to `x_x`, so try it at both ends.
 
+### The line is small and the blast radius is not
+
+Read this before opening the PR, because the diff looks free and is not.
+
+A creature is picked with `pool[Hash(key) % len(pool)]`, so **growing a band
+changes which creature every existing key in that band draws.** Adding one
+Common is enough. Measured, from adding a single new Common:
+
+```
+For("main")   mouse -> toad
+For("master") vole  -> toad
+For("trunk")  wren  -> moth
+For("a")      crab  -> carp
+```
+
+Three consequences, in rising order of how much they matter:
+
+1. Two tests fail, in two packages: the golden pin in `internal/identity` and a
+   party test in `internal/render`. That is the pin doing its job, not a mistake
+   you made. Repin it in the same PR.
+2. Everyone's pet changes when they upgrade. The mouse someone has had in `main`
+   for a month becomes a toad.
+3. `den.json` keeps the **old** species names, and it is the only precious state
+   here. So `collection.Has()` stops matching what is on screen: the den quietly
+   re-earns creatures it already holds, and the entries it held before become
+   unreachable, because no key summons them any more.
+
+None of that is a reason never to add creatures. It is the reason roster growth
+is batched into a release and called out in the notes, rather than merged one
+cute animal at a time. If you have a creature you like, open it anyway and say
+so - it may just wait for company.
+
 ## Adding a signal
 
 A signal is any executable that prints `key=value` lines on stdout. It receives
@@ -83,10 +115,12 @@ the collection. Nothing else on disk is touched.
 
 Two things worth knowing before changing them:
 
-**Identity must stay stable.** A branch is supposed to summon the same creature
-forever, on any machine. `internal/identity` has a golden test pinning specific
-branch names to specific creatures, and it is there to make an accidental
-reshuffle loud. If you change identity deliberately, repin it and say so.
+**Identity must stay stable.** A key is supposed to summon the same creature on
+any machine, for as long as the roster holds still. `internal/identity` has a
+golden test pinning specific keys to specific creatures, and it is there to make
+an accidental reshuffle loud. If you change identity deliberately, repin it and
+say so. Adding a creature is one of the ways to change it: see [the blast radius
+above](#the-line-is-small-and-the-blast-radius-is-not).
 
 **The render path never runs git and never touches the network.** `pets render`
 executes once a second in every open session, so it reads two small files and

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -1,7 +1,9 @@
 // Package identity derives a creature from one opaque key.
 //
 // Nothing here touches disk or network: the same key yields the same creature on
-// every machine, forever, with nothing persisted. Rarity is a weighted band over
+// every machine, with nothing persisted. That holds for as long as the roster
+// does - a creature is drawn with pool[hash%len], so growing a band reassigns
+// every key already in it, which CONTRIBUTING.md covers as a release-sized event. Rarity is a weighted band over
 // the same hash, so a collection costs no extra state.
 //
 // Callers decide what the key means, and they deliberately disagree. Live


### PR DESCRIPTION
Follow-on from #43, and a correction to it.

## The problem

`CONTRIBUTING.md` opens with:

> Creatures live in one slice in `internal/identity/identity.go`. Adding one is a **single line**

and then, eighty lines later, in a different section:

> **Identity must stay stable.** [the golden test] is there to make an accidental reshuffle loud.

Nothing connected those. Adding a creature *is* a deliberate reshuffle, so a contributor followed the one-line framing, hit failing tests they didn't cause, and had no way to know the real cost. This matters more now that the project is being pitched on the cosmetic/customization angle, which invites exactly this PR.

## What it costs, measured

A creature is drawn with `pool[Hash(key) % len(pool)]`, so growing a band reassigns every key already in it. Adding one Common:

```
For("main")   mouse -> toad
For("master") vole  -> toad
For("trunk")  wren  -> moth
For("a")      crab  -> carp
```

Two tests fail, in two packages (the golden pin in `internal/identity`, a party test in `internal/render`).

## The part nobody had written down

`den.json` stores species **names**, and `internal/den`'s own doc calls it "the only precious state in the project". So after a reshuffle the collection stops matching reality. Verified directly:

```
den holds "mouse" (common); Has(recorded)=true  distinct=1
after roster growth main summons "toad";  Has(that)=false
```

The den quietly re-earns the new creature, and the entry it already held becomes unreachable, because no key summons `mouse` from `main` any more.

That is not an argument against new creatures. It is why roster growth should be batched into a release and called out in the notes rather than merged one cute animal at a time - and the new section says exactly that, while still telling contributors to open the PR anyway.

## Also a correction to #43

The package doc I wrote in #43 claimed the same key yields the same creature "forever". This contradicts it, so the word is gone: the guarantee holds for as long as the roster does.

## On measuring before writing

Worth recording, since I nearly shipped it wrong. My first pass used `newt` as the new species - which **already exists** in the roster, so one of the three failures I was about to document was my own duplicate-name error rather than a consequence of growth. I also wrote `main`'s creature as `otter` when the pin says `mouse`. Both corrected by re-running with a genuinely new name; the numbers above are the second measurement.

No behaviour change. Docs and one comment. Suite green.