### PR TITLE
Point creature contributors at the open policy question

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,11 @@ is batched into a release and called out in the notes, rather than merged one
 cute animal at a time. If you have a creature you like, open it anyway and say
 so - it may just wait for company.
 
+Whether that stays the policy is [an open
+question](https://github.com/TevvvB/parallel-harness-pets/discussions/46), and
+the answer partly depends on how many creatures are waiting. Post yours there
+too.
+
 ## Adding a signal
 
 A signal is any executable that prints `key=value` lines on stdout. It receives


### PR DESCRIPTION
One line. #44's new section states the batching policy as settled, but discussion #46 is asking whether it should be, and the answer depends partly on how many creatures are waiting. Sends contributors into that conversation instead of handing them a decree.

Docs only.