### PR TITLE
Give the hook line the state the status line shows

### DIFF
--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -473,7 +473,7 @@ func quipCommand() {
 	if !ok {
 		return
 	}
-	message := fmt.Sprintf("%s %s: %s", view.Body(), view.Pet.Name, quipFor(view))
+	message := render.HookMessage(view, settings, quipFor(view))
 	encoded, err := json.Marshal(map[string]string{"systemMessage": message})
 	if err != nil {
 		return

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -74,12 +74,36 @@ func (v View) Body() string {
 }
 
 func (v View) hearts() string {
+	filled, empty := v.heartGlyphs()
 	if !v.HasState {
-		return dim + "·····" + reset
+		return dim + empty + reset
 	}
-	filled := strings.Repeat("♥", v.Score.Hearts)
-	empty := strings.Repeat("♡", score.Max-v.Score.Hearts)
 	return heartHue + filled + dim + empty + reset
+}
+
+// heartGlyphs splits the bar so a surface that cannot take ANSI still shows the score.
+func (v View) heartGlyphs() (filled, empty string) {
+	if !v.HasState {
+		return "", "·····"
+	}
+	return strings.Repeat("♥", v.Score.Hearts), strings.Repeat("♡", score.Max-v.Score.Hearts)
+}
+
+// HookMessage is the whole readout for a surface that gets one line and no status bar.
+//
+// Deliberately monochrome: a host like Codex prints this as body text among its own
+// output, and raw ANSI is not guaranteed to survive or to suit its palette. Without the
+// glyphs the line was just a creature and one sentence, which lost the score and two of
+// the three counts the status line would have shown.
+func HookMessage(v View, settings config.Config, quip string) string {
+	parts := []string{v.Body(), v.Pet.Name}
+	if filled, empty := v.heartGlyphs(); v.HasState {
+		parts = append(parts, filled+empty)
+	}
+	if flags := v.Flags(settings); v.HasState && len(flags) > 0 {
+		parts = append(parts, strings.Join(flags, " "))
+	}
+	return strings.Join(parts, " ") + " · " + quip
 }
 
 // Flags are the raw counts behind the mood, shown only when they are non-zero.

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -266,3 +266,27 @@ func TestPartyDoesNotRepeatTheCreatureOfALoneResident(t *testing.T) {
 		}
 	}
 }
+
+// The Codex Stop hook gets one line and no status bar, and it used to carry only the
+// creature and a sentence: the score and two of the three counts were simply absent, so
+// the readout barely registered among the host's own output.
+func TestHookMessageCarriesScoreAndCounts(t *testing.T) {
+	view := View{
+		Pet:      identity.For("main"),
+		HasState: true,
+		Score:    score.Result{Hearts: 1},
+		State:    state.State{Dirty: 31, Unpushed: 27, Behind: 250},
+	}
+	message := HookMessage(view, config.Default(), "this branch only exists on your laptop.")
+
+	for _, want := range []string{"♥♡♡♡♡", "31△", "27↑", "250↓", view.Pet.Name} {
+		if !strings.Contains(message, want) {
+			t.Errorf("hook message %q is missing %q", message, want)
+		}
+	}
+	// A host that prints this as body text may not survive raw escapes, and we cannot
+	// know its palette either way.
+	if strings.Contains(message, "\033") {
+		t.Errorf("hook message carries ANSI: %q", message)
+	}
+}


### PR DESCRIPTION
Tevan ran this against a real Codex session and said it "barely shows". He was right.

## Before and after, same repo and moment

```
status line:  >(@_@)< crab @ PAR · DIL-3982… ♥♡♡♡♡ 31△ 27↑ 250↓     (6 colours)
Stop hook:    >(@_@)< crab: 27 unpushed. this branch only exists on your laptop.
```

The hook line dropped the score and two of the three counts. That worktree was on **one heart** and **250 behind trunk**, and the hook mentioned neither. Now:

```
Stop (completed) says: >(@_@)< crab ♥♡♡♡♡ 31△ 27↑ 250↓ · 27 unpushed. this branch only exists on your laptop.
```

## Why monochrome

The host renders this as body text among its own output. I started to probe whether Codex survives raw ANSI in a hook message and stopped: a line whose legibility depends on escape codes surviving someone else's TUI is fragile even when it happens to work, and we cannot know their palette. So the glyphs have to read without colour, and there is a test asserting no ANSI leaks into the message.

`Flags()` was already plain text and is reused as-is. The heart glyphs are split out of `hearts()` rather than duplicated, so the coloured and plain forms cannot drift apart.

## Verified by mutation

Reverted `HookMessage` to the old one-liner and confirmed the new test fails on all four missing pieces, then restored. Full suite green, `gofmt` and `vet` clean.

## Two things I deliberately did **not** change

- **`27↑` and "27 unpushed" now say the same number twice.** The tidy fix is to strip counts out of `quipFor`'s strings so glyphs carry the data and the quip carries only the voice - but that rewrites all five quip strings, which is user-visible personality, so it is Tevan's call not mine.
- **`quipFor` ranks `Unpushed > 5` above `Dirty > 15`**, which is why 31 uncommitted files lost to 27 unpushed commits. Uncommitted work exists only on disk while unpushed commits are already safe in git objects, so the order is arguably inverted - but again, taste, not defect.