### PR TITLE
Put the place back in the hook line

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -93,10 +93,14 @@ func (v View) heartGlyphs() (filled, empty string) {
 //
 // Deliberately monochrome: a host like Codex prints this as body text among its own
 // output, and raw ANSI is not guaranteed to survive or to suit its palette. Without the
-// glyphs the line was just a creature and one sentence, which lost the score and two of
-// the three counts the status line would have shown.
+// glyphs the line was just a creature and one sentence, which lost the place, the score
+// and two of the three counts the status line would have shown. The place matters most of
+// the three: it is the only part that says which worktree is talking.
 func HookMessage(v View, settings config.Config, quip string) string {
 	parts := []string{v.Body(), v.Pet.Name}
+	if home := v.Home(); home != "" {
+		parts = append(parts, home)
+	}
 	if filled, empty := v.heartGlyphs(); v.HasState {
 		parts = append(parts, filled+empty)
 	}

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -273,13 +273,14 @@ func TestPartyDoesNotRepeatTheCreatureOfALoneResident(t *testing.T) {
 func TestHookMessageCarriesScoreAndCounts(t *testing.T) {
 	view := View{
 		Pet:      identity.For("main"),
+		Place:    identity.PlaceForKey("place:demo#demo"),
 		HasState: true,
 		Score:    score.Result{Hearts: 1},
 		State:    state.State{Dirty: 31, Unpushed: 27, Behind: 250},
 	}
 	message := HookMessage(view, config.Default(), "this branch only exists on your laptop.")
 
-	for _, want := range []string{"♥♡♡♡♡", "31△", "27↑", "250↓", view.Pet.Name} {
+	for _, want := range []string{"@ " + view.Place.Code, "♥♡♡♡♡", "31△", "27↑", "250↓", view.Pet.Name} {
 		if !strings.Contains(message, want) {
 			t.Errorf("hook message %q is missing %q", message, want)
 		}


### PR DESCRIPTION
Follow-on to #48, fixing something I left out of it.

#48 gave the hook line the score and the counts and dropped the one part that identifies *which worktree is talking*. Tevan looked at a real Codex session and that was the first thing he noticed.

```
before  >(@_@)< crab ♥♡♡♡♡ 31△ 27↑ 250↓ · 27 unpushed. this branch only exists on your laptop.
after   >(@_@)< crab @ PAR ♥♡♡♡♡ 31△ 27↑ 250↓ · 27 unpushed. this branch only exists on your laptop.
```

For comparison, the status line for the same worktree:

```
>(@_@)< crab @ PAR · DIL-3982-income-calculati… ♥♡♡♡♡ 31△ 27↑ 250↓
```

The branch stays out on purpose: Codex's status line already has a built-in `GitBranch` item, and it is the longest element for the least benefit in a one-line message.

The existing `HookMessage` test now asserts the place too, and gained a `Place` on its fixture so it would actually catch this — without it the assertion passes vacuously on an empty `Place.Code`.