### PR TITLE
Lay the hook readout out as a block, not a sentence

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -91,23 +91,36 @@ func (v View) heartGlyphs() (filled, empty string) {
 
 // HookMessage is the whole readout for a surface that gets one line and no status bar.
 //
-// Deliberately monochrome: a host like Codex prints this as body text among its own
-// output, and raw ANSI is not guaranteed to survive or to suit its palette. Without the
-// glyphs the line was just a creature and one sentence, which lost the place, the score
-// and two of the three counts the status line would have shown. The place matters most of
-// the three: it is the only part that says which worktree is talking.
+// Three rows, because Codex splits systemMessage on newlines and indents every row after
+// the first by four spaces, uncapped: only its separate hook-context path truncates at
+// three. So identity, state and voice each get their own row and the thing reads as a
+// block instead of one long sentence trailing off the prefix.
+//
+// Deliberately monochrome: the host prints this as body text, raw ANSI is not guaranteed
+// to survive, and its palette is unknowable from here.
 func HookMessage(v View, settings config.Config, quip string) string {
-	parts := []string{v.Body(), v.Pet.Name}
+	who := []string{v.Body(), v.Pet.Name}
 	if home := v.Home(); home != "" {
-		parts = append(parts, home)
+		who = append(who, home)
 	}
-	if filled, empty := v.heartGlyphs(); v.HasState {
-		parts = append(parts, filled+empty)
+	rows := []string{strings.Join(who, " ")}
+	if state := v.stateRow(settings); state != "" {
+		rows = append(rows, state)
 	}
-	if flags := v.Flags(settings); v.HasState && len(flags) > 0 {
-		parts = append(parts, strings.Join(flags, " "))
+	return strings.Join(append(rows, quip), "\n")
+}
+
+// stateRow is the score and counts a status line would show, without colour.
+func (v View) stateRow(settings config.Config) string {
+	if !v.HasState {
+		return ""
 	}
-	return strings.Join(parts, " ") + " · " + quip
+	filled, empty := v.heartGlyphs()
+	row := filled + empty
+	if flags := v.Flags(settings); len(flags) > 0 {
+		row += "  " + strings.Join(flags, " ")
+	}
+	return row
 }
 
 // Flags are the raw counts behind the mood, shown only when they are non-zero.

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -280,9 +280,18 @@ func TestHookMessageCarriesScoreAndCounts(t *testing.T) {
 	}
 	message := HookMessage(view, config.Default(), "this branch only exists on your laptop.")
 
-	for _, want := range []string{"@ " + view.Place.Code, "♥♡♡♡♡", "31△", "27↑", "250↓", view.Pet.Name} {
-		if !strings.Contains(message, want) {
-			t.Errorf("hook message %q is missing %q", message, want)
+	// Three rows: Codex puts the first after its own prefix and indents the rest, so the
+	// split is what makes this read as a block rather than one trailing sentence.
+	rows := strings.Split(message, "\n")
+	if len(rows) != 3 {
+		t.Fatalf("want 3 rows, got %d: %q", len(rows), message)
+	}
+	if !strings.Contains(rows[0], view.Pet.Name) || !strings.Contains(rows[0], "@ "+view.Place.Code) {
+		t.Errorf("first row should say who and where, got %q", rows[0])
+	}
+	for _, want := range []string{"♥♡♡♡♡", "31△", "27↑", "250↓"} {
+		if !strings.Contains(rows[1], want) {
+			t.Errorf("state row %q is missing %q", rows[1], want)
 		}
 	}
 	// A host that prints this as body text may not survive raw escapes, and we cannot


### PR DESCRIPTION
Tevan asked whether spacing could make the hook line read more like a status bar. It can.

## What Codex actually does with `systemMessage`

From `codex-rs/tui/src/history_cell/hook_cell.rs`, it splits on newlines, puts the **first** row inline after its prefix, and gives every later row its own line at a fixed four-space indent. Their own test in that file:

```
"* Stop (completed) says: Heads up",
"    Review generated files",
```

The `HOOK_CONTEXT_MAX_DISPLAY_ROWS = 3` truncation people notice is on the *hook context* path, not this one - `systemMessage` rows are pushed uncapped. Blank lines survive too.

## Result

```
* Stop (completed) says: >(@_@)< crab @ PAR
      HHHoo  31^ 27^ 253v
      27 unpushed. this branch only exists on your laptop.
```

(glyphs flattened for this description; the real rows use the heart bar and the arrow flags)

Identity, state, voice. Separating the data from the sentence also removes the wart from #48 where the unpushed count appeared twice in one line.

## Still monochrome

Unchanged and deliberate. `codex exec` never surfaces `systemMessage` at all - verified across three runs where hooks completed and pets wrote state but the text never appeared - so whether the interactive TUI honours ANSI cannot be settled from a headless probe.

Worth recording that **a raw escape byte makes the hook fail outright** - `hook: Stop Failed`, because a raw control character is invalid JSON. Go's `json.Marshal` escapes it automatically so we would be safe, but anything hand-rolling this message in shell breaks silently.

## Verified

The test asserts three rows and which row carries what; collapsing the join back to a space fails it with `want 3 rows, got 1`. Full suite, vet and gofmt clean.

If three rows per turn reads as too much, the two-row variant - state and quip sharing the second row - is a one-line change.
