### PR TITLE
Give the creature its own row

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -91,10 +91,10 @@ func (v View) heartGlyphs() (filled, empty string) {
 
 // HookMessage is the whole readout for a surface that gets one line and no status bar.
 //
-// Three rows, because Codex splits systemMessage on newlines and indents every row after
-// the first by four spaces, uncapped: only its separate hook-context path truncates at
-// three. So identity, state and voice each get their own row and the thing reads as a
-// block instead of one long sentence trailing off the prefix.
+// Codex splits systemMessage on newlines, renders the first row inline after its own
+// "says:" prefix, and indents every later row by four spaces, uncapped: only its separate
+// hook-context path truncates at three. The first row is left empty so the creature,
+// the state and the voice all land in the indented block and line up with each other.
 //
 // Deliberately monochrome: the host prints this as body text, raw ANSI is not guaranteed
 // to survive, and its palette is unknowable from here.
@@ -103,7 +103,9 @@ func HookMessage(v View, settings config.Config, quip string) string {
 	if home := v.Home(); home != "" {
 		who = append(who, home)
 	}
-	rows := []string{strings.Join(who, " ")}
+	// Leading blank so the creature gets its own row: Codex renders the first row inline
+	// after its "says:" prefix, and only later rows land on the indented block.
+	rows := []string{"", strings.Join(who, " ")}
 	if state := v.stateRow(settings); state != "" {
 		rows = append(rows, state)
 	}

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -280,18 +280,22 @@ func TestHookMessageCarriesScoreAndCounts(t *testing.T) {
 	}
 	message := HookMessage(view, config.Default(), "this branch only exists on your laptop.")
 
-	// Three rows: Codex puts the first after its own prefix and indents the rest, so the
-	// split is what makes this read as a block rather than one trailing sentence.
+	// Codex puts the first row inline after its own prefix and indents the rest, so the
+	// leading empty row is what gets the creature onto a line of its own with the state
+	// and the quip lined up under it.
 	rows := strings.Split(message, "\n")
-	if len(rows) != 3 {
-		t.Fatalf("want 3 rows, got %d: %q", len(rows), message)
+	if len(rows) != 4 {
+		t.Fatalf("want 4 rows, got %d: %q", len(rows), message)
 	}
-	if !strings.Contains(rows[0], view.Pet.Name) || !strings.Contains(rows[0], "@ "+view.Place.Code) {
-		t.Errorf("first row should say who and where, got %q", rows[0])
+	if rows[0] != "" {
+		t.Errorf("first row must be empty or the creature shares Codex's prefix row, got %q", rows[0])
+	}
+	if !strings.Contains(rows[1], view.Pet.Name) || !strings.Contains(rows[1], "@ "+view.Place.Code) {
+		t.Errorf("creature row should say who and where, got %q", rows[1])
 	}
 	for _, want := range []string{"♥♡♡♡♡", "31△", "27↑", "250↓"} {
-		if !strings.Contains(rows[1], want) {
-			t.Errorf("state row %q is missing %q", rows[1], want)
+		if !strings.Contains(rows[2], want) {
+			t.Errorf("state row %q is missing %q", rows[2], want)
 		}
 	}
 	// A host that prints this as body text may not survive raw escapes, and we cannot


### PR DESCRIPTION
Follow-on to #50, from Tevan looking at it in a live session.

Codex renders the first row of `systemMessage` inline after its own `says:` prefix, so the creature was sharing a line with Codex's label while the state and quip sat in the indented block below it. Leaving the first row empty moves all three into the block:

```
before   * Stop (completed) says: v(@_@)v wren @ PAR
               <hearts>  31^ 27^ 253v
               27 unpushed. this branch only exists on your laptop.

after    * Stop (completed) says:
               v(@_@)v wren @ PAR
               <hearts>  31^ 27^ 253v
               27 unpushed. this branch only exists on your laptop.
```

The cost is that `says:` trails off with nothing after it. That prefix is Codex's and cannot be suppressed from here; reviewed live and it reads as a heading over a block.

The test pins the empty first row with an explicit message, so a future cleanup that removes the 'stray' blank fails loudly instead of silently undoing this. Verified by mutation: dropping it gives `want 4 rows, got 3`.