### PR TITLE
Bump the plugin manifests to 0.2.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A creature for every agent session, living in your status line",
-    "version": "0.2.7"
+    "version": "0.2.8"
   },
   "plugins": [
     {
       "name": "pets",
       "source": "./plugin",
       "description": "The /pets skill plus a one-command setup. Gives every agent session its own creature in the status line, with a den per git worktree, rarity bands and 16 cities to collect.",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "category": "fun",
       "keywords": [
         "statusline",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pets",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A creature for every agent session, in a den for every git worktree. Its mood tracks how tidy that worktree is, so several agents at once stay tellable apart at a glance.",
   "author": {
     "name": "TevvvB",


### PR DESCRIPTION
Release prep for v0.2.8. All three manifest spots, which the release workflow gates on.

Shipping since v0.2.7 (23 Aug):

- #42 pin the Codex payload shape with a captured fixture
- #43 document the identity model the callers actually use
- #44 say what adding a creature actually costs
- #47 point creature contributors at the open policy question
- #48 give the hook line the state the status line shows
- #49 put the place back in the hook line
- #50 lay the hook readout out as a block
- #51 give the creature its own row