### PR TITLE
Let user signals reach the pet's face

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,11 @@ the worktree path as its first argument. Drop it in `~/.config/pets/signals/`.
 echo "clippy=$(cargo clippy --message-format=short 2>&1 | grep -c '^warning')"
 ```
 
+By default that only adds a row to `pets card`. Give it a bound and a cost under
+`[signals.external.penalties.<name>]` and it costs hearts like the built-in signals,
+and the card shows it in amber. `over` for things that are bad when they rise,
+`under` for things that are bad when they fall.
+
 Signals are user configuration rather than part of the tool, so there is nothing
 to submit unless you want one documented in the README as an example.
 

--- a/README.md
+++ b/README.md
@@ -260,14 +260,31 @@ penalty = 2
 ### Teaching it your stack
 
 Any executable that prints `key=value` lines is a signal. Drop it in
-`~/.config/pets/signals/` and it is scored with the built-in ones. It gets the
-worktree path as its first argument.
+`~/.config/pets/signals/`. It gets the worktree path as its first argument.
 
 ```sh
 #!/bin/sh
 # ~/.config/pets/signals/cargo.sh
 echo "clippy=$(cargo clippy --message-format=short 2>&1 | grep -c '^warning')"
+echo "coverage=$(grep -o '[0-9]*' target/coverage 2>/dev/null || echo 100)"
 ```
+
+That much shows up on `pets card`. To make it reach the pet's face, give it a rule:
+
+```toml
+[signals.external.penalties.clippy]
+over = 0      # bad when it goes up
+cost = 1
+
+[signals.external.penalties.coverage]
+under = 80    # bad when it goes down
+cost = 2
+```
+
+Two bounds, because half of what people measure is bad going up and half is bad
+going down. A signal with no rule stays display-only, and a signal that did not
+report is not treated as reporting zero, so a probe that fails to run cannot
+sadden the pet on its own.
 
 ## Contributing
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,8 +41,28 @@ type Migrations struct {
 }
 
 type External struct {
-	Dir       string `toml:"dir"`
-	TimeoutMs int    `toml:"timeout_ms"`
+	Dir       string                     `toml:"dir"`
+	TimeoutMs int                        `toml:"timeout_ms"`
+	Penalties map[string]ExternalPenalty `toml:"penalties"`
+}
+
+// ExternalPenalty makes one user signal count against the score.
+//
+// Two bounds because half of what people measure is bad going up (warnings, TODOs,
+// drifted resources) and half is bad going down (coverage, checks passing). Pointers so
+// that "over = 0", the most useful rule there is, is distinguishable from unset.
+type ExternalPenalty struct {
+	Over  *int `toml:"over"`
+	Under *int `toml:"under"`
+	Cost  int  `toml:"cost"`
+}
+
+// Triggered reports whether a reported value breaches this rule.
+func (p ExternalPenalty) Triggered(value int) bool {
+	if p.Over != nil && value > *p.Over {
+		return true
+	}
+	return p.Under != nil && value < *p.Under
 }
 
 // Update controls the once-a-day check for a newer release. It runs only from

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -425,7 +425,7 @@ func Card(v View, settings config.Config) string {
 	}
 	row("last tests", v.Tests, penalised["tests"])
 	for name, value := range v.State.External {
-		row(name, fmt.Sprint(value), false)
+		row(name, fmt.Sprint(value), penalised[name])
 	}
 	now := time.Now()
 	out.WriteString(Residents(v, now))

--- a/internal/score/score.go
+++ b/internal/score/score.go
@@ -2,6 +2,8 @@
 package score
 
 import (
+	"sort"
+
 	"github.com/TevvvB/parallel-harness-pets/internal/config"
 	"github.com/TevvvB/parallel-harness-pets/internal/state"
 )
@@ -45,6 +47,15 @@ func Of(current state.State, tests string, settings config.Config) Result {
 	if settings.Signals.Migrations.Enabled {
 		charge("migrations", settings.Signals.Migrations.Penalty, current.Migrations > 1)
 	}
+	// Sorted so the card lists reasons in a stable order rather than map order.
+	for _, name := range sortedNames(settings.Signals.External.Penalties) {
+		// A signal that did not report is not a signal reading zero, so an absent
+		// coverage probe must not trip an "under 80" rule.
+		if value, reported := current.External[name]; reported {
+			charge(name, settings.Signals.External.Penalties[name].Cost,
+				settings.Signals.External.Penalties[name].Triggered(value))
+		}
+	}
 
 	if result.Hearts < 0 {
 		result.Hearts = 0
@@ -53,6 +64,15 @@ func Of(current state.State, tests string, settings config.Config) Result {
 		result.Hearts = Max
 	}
 	return result
+}
+
+func sortedNames(penalties map[string]config.ExternalPenalty) []string {
+	names := make([]string, 0, len(penalties))
+	for name := range penalties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func Face(hearts int) string {

--- a/internal/score/score_test.go
+++ b/internal/score/score_test.go
@@ -80,3 +80,48 @@ func TestFaceDegradesWithHearts(t *testing.T) {
 		previous = face
 	}
 }
+
+func intPtr(value int) *int { return &value }
+
+// The whole premise is that the face reflects the worktree, and external signals were the
+// one user-extensible input that could not touch it: score never read State.External, so a
+// signal reporting 40 clippy warnings left the pet delighted.
+func TestExternalSignalsCostHearts(t *testing.T) {
+	settings := config.Default()
+	settings.Signals.External.Penalties = map[string]config.ExternalPenalty{
+		"clippy":   {Over: intPtr(0), Cost: 2},
+		"coverage": {Under: intPtr(80), Cost: 1},
+	}
+
+	clean := Of(state.State{External: map[string]int{"clippy": 0, "coverage": 95}}, "pass", settings)
+	if clean.Hearts != settings.Score.Start {
+		t.Errorf("signals within their bounds cost %d hearts", settings.Score.Start-clean.Hearts)
+	}
+
+	breached := Of(state.State{External: map[string]int{"clippy": 40, "coverage": 61}}, "pass", settings)
+	if want := settings.Score.Start - 3; breached.Hearts != want {
+		t.Errorf("hearts = %d, want %d after both rules fired", breached.Hearts, want)
+	}
+	// The card explains itself from these, so each breach has to name its own signal.
+	named := map[string]bool{}
+	for _, penalty := range breached.Penalties {
+		named[penalty.Signal] = true
+	}
+	if !named["clippy"] || !named["coverage"] {
+		t.Errorf("penalties %+v do not name both signals", breached.Penalties)
+	}
+}
+
+// A probe that did not run reports nothing, which is not the same as reporting zero. Left
+// unguarded, every "under" rule fires on every worktree where the signal is absent.
+func TestUnreportedExternalSignalIsNotZero(t *testing.T) {
+	settings := config.Default()
+	settings.Signals.External.Penalties = map[string]config.ExternalPenalty{
+		"coverage": {Under: intPtr(80), Cost: 2},
+	}
+
+	result := Of(state.State{External: map[string]int{}}, "pass", settings)
+	if result.Hearts != settings.Score.Start {
+		t.Errorf("an absent coverage signal cost %d hearts", settings.Score.Start-result.Hearts)
+	}
+}


### PR DESCRIPTION
Closes #45.

`score.Of` never read `state.External`, so the one user-extensible input could not touch the expression the whole tool is built around. `render.go` even hardcoded `false` for its penalised flag. Write a signal reporting 40 clippy warnings and the pet stayed delighted.

## The config

```toml
[signals.external.penalties.clippy]
over = 0      # bad when it goes up
cost = 1

[signals.external.penalties.coverage]
under = 80    # bad when it goes down
cost = 2
```

Two bounds, because half of what people measure is bad rising and half is bad falling. `*int` rather than `int` so `over = 0` - the most useful rule there is - is distinguishable from unset.

## Verified end to end, not just in unit tests

A real signal script, a real config, a real worktree:

```
with penalties      mood  HHooo  1/5     clippy 40 (amber)  coverage 61 (amber)
penalties removed   mood  HHHHo  4/5     clippy 40 (plain)
```

4/5 to 1/5 is exactly the configured 2 + 1, and the two rows pick up the same amber (`38;5;179`) the built-in signals use, because `penalised` is keyed on the penalty's `Signal` name.

## Two details that are not obvious

- **An absent signal is not a signal reporting zero.** Unguarded, every `under` rule fires on every worktree where the probe did not run. There is a test for it, and dropping the guard fails with `an absent coverage signal cost 2 hearts`.
- **Rules are charged in sorted order.** Map order would make the card list its reasons differently on each render.

A signal with no rule keeps today's display-only behaviour, which was the compatibility requirement in the issue.

## A doc that was already lying

The README said a signal dropped in `signals/` "is scored with the built-in ones". That was never true. It is now, with a rule, and both README and CONTRIBUTING say what actually happens.

## Scope

Two tests, both mutation-verified. No weighting system, no expression language, no per-band tuning - two optional bounds and a cost, as the issue asked.
