### PR TITLE
Bump the plugin manifests to 0.2.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A creature for every agent session, living in your status line",
-    "version": "0.2.8"
+    "version": "0.2.9"
   },
   "plugins": [
     {
       "name": "pets",
       "source": "./plugin",
       "description": "The /pets skill plus a one-command setup. Gives every agent session its own creature in the status line, with a den per git worktree, rarity bands and 16 cities to collect.",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "category": "fun",
       "keywords": [
         "statusline",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pets",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "A creature for every agent session, in a den for every git worktree. Its mood tracks how tidy that worktree is, so several agents at once stay tellable apart at a glance.",
   "author": {
     "name": "TevvvB",


### PR DESCRIPTION
Release prep for v0.2.9, the first release under the new name.

Shipping since v0.2.8:
- #54 let user signals reach the pet's face (closes #45)
- #55 rename to termagitchi
- #53 dependabot: codeql-action v4.37.8

Release assets will carry the `termagitchi_` prefix for the first time, since `project_name` is now pinned in `.goreleaser.yaml`. The tap's `update-casks` workflow regenerates from the release's `checksums.txt`, so it needs `cask_renames.json` in place to migrate existing installs rather than stranding them on the old cask.