### PR TITLE
Give Windows a package manager

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -41,8 +41,10 @@ brew install TevvvB/tap/termagitchi
 pets install
 ```
 
-**Windows** — [Releases](https://github.com/TevvvB/termagitchi/releases)
-からアーカイブを取得し、`pets` を `PATH` に置いてから `pets install` を実行してください。
+**Windows** — `scoop bucket add tevvvb https://github.com/TevvvB/scoop-bucket` の後に
+`scoop install termagitchi`、そして `pets install` を実行してください。
+[Releases](https://github.com/TevvvB/termagitchi/releases) からアーカイブを取得して
+`pets` を自分で `PATH` に置く方法でも構いません。
 
 **Go を使う場合** — `go install github.com/TevvvB/termagitchi/cmd/pets@latest`
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -41,8 +41,10 @@ brew install TevvvB/tap/termagitchi
 pets install
 ```
 
-**Windows** — [Releases](https://github.com/TevvvB/termagitchi/releases)에서
-아카이브를 받아 `pets`를 `PATH`에 두고 `pets install`을 실행하세요.
+**Windows** — `scoop bucket add tevvvb https://github.com/TevvvB/scoop-bucket` 후
+`scoop install termagitchi`, 그리고 `pets install`을 실행하세요.
+또는 [Releases](https://github.com/TevvvB/termagitchi/releases)에서 아카이브를 받아
+`pets`를 직접 `PATH`에 두어도 됩니다.
 
 **Go로 설치** — `go install github.com/TevvvB/termagitchi/cmd/pets@latest`
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ The plugin carries the two skills; `pets install` still owns the status line and
 hooks, which is what `/pets-setup` runs. You need the binary either way - a plugin
 carries configuration, not executables. See [plugin/README.md](plugin/README.md).
 
-**Windows** - grab an archive from
-[Releases](https://github.com/TevvvB/termagitchi/releases), put `pets`
-on your `PATH`, then run `pets install`.
+**Windows** - `scoop bucket add tevvvb https://github.com/TevvvB/scoop-bucket`
+then `scoop install termagitchi`, and run `pets install`. Or grab an archive from
+[Releases](https://github.com/TevvvB/termagitchi/releases) and put `pets` on your
+`PATH` yourself.
 
 **With Go** - `go install github.com/TevvvB/termagitchi/cmd/pets@latest`
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -41,8 +41,10 @@ brew install TevvvB/tap/termagitchi
 pets install
 ```
 
-**Windows** — 从 [Releases](https://github.com/TevvvB/termagitchi/releases)
-下载压缩包，把 `pets` 放到 `PATH` 里，然后运行 `pets install`。
+**Windows** — 先 `scoop bucket add tevvvb https://github.com/TevvvB/scoop-bucket`，
+再 `scoop install termagitchi`，然后运行 `pets install`。
+也可以从 [Releases](https://github.com/TevvvB/termagitchi/releases) 下载压缩包，
+自己把 `pets` 放到 `PATH` 里。
 
 **用 Go 安装** — `go install github.com/TevvvB/termagitchi/cmd/pets@latest`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,22 +15,24 @@ user on whatever they installed. It drifted three releases before anyone noticed
 release now fails on a mismatch rather than trusting the habit. If it fails, fix the
 manifests, delete the tag, and tag again.
 
-## The Homebrew cask updates itself
+## The Homebrew cask and the Scoop manifest update themselves
 
 [The tap](https://github.com/TevvvB/homebrew-tap) carries a workflow that polls
 this repository's latest release every six hours, and can be run on demand:
 
 ```sh
 gh workflow run update-casks.yml --repo TevvvB/homebrew-tap
+gh workflow run update-manifests.yml --repo TevvvB/scoop-bucket
 ```
 
-It regenerates the cask from the release's `checksums.txt` and pushes.
+Each regenerates its manifest from the release's `checksums.txt` and pushes.
 
 **No token is involved.** A workflow in this repository could not write to the
 tap without a personal access token, but a workflow in the tap can write to the
 tap with its own `GITHUB_TOKEN`. Pulling from the release rather than pushing to
 the tap removes the secret entirely, which is why `.goreleaser.yaml` keeps
-`skip_upload` set on the cask and the scoop manifest.
+`skip_upload` set on both the cask and the scoop manifest: goreleaser must not
+push to either, because each one pulls.
 
 It also makes the checksum rule structural rather than a thing to remember: the
 updater has no local build to take hashes from, only the published
@@ -40,8 +42,9 @@ would fail verification.
 
 ## Platforms
 
-Homebrew casks are macOS only. Linux and Windows users take a release archive or
-`go install`. The Linux blocks GoReleaser writes into the cask are unreachable,
+Homebrew casks are macOS only; the [Scoop
+bucket](https://github.com/TevvvB/scoop-bucket) covers Windows. Linux users take a
+release archive or `go install`. The Linux blocks GoReleaser writes into the cask are unreachable,
 and harmless.
 
 ## Checks


### PR DESCRIPTION
Windows was the one platform with no install route but a raw archive.

The `scoops:` block in `.goreleaser.yaml` has pointed at `TevvvB/scoop-bucket` since the start with `skip_upload` set. The bucket just never existed. It does now:

```powershell
scoop bucket add tevvvb https://github.com/TevvvB/scoop-bucket
scoop install termagitchi
pets install
```

## Same no-token architecture as the tap

`skip_upload` stays set deliberately. The bucket carries its own workflow that polls this repository's latest release every six hours and regenerates the manifest from the published `checksums.txt`. A workflow here could not write to the bucket without a PAT; the bucket's own `GITHUB_TOKEN` can write to the bucket. So there is no secret anywhere, and the hashes can only come from the artefacts people actually download — the build is not byte-reproducible, so locally generated hashes would fail every install.

I deliberately did **not** add `checkver`/`autoupdate` to the manifest. The workflow already updates it, and two mechanisms writing the same file is worse than one.

## Verified before documenting

Dispatched a run against the current release: it reported `latest=0.2.9 current=0.2.9`, no-opped correctly, and left no spurious commit. Manifest validates as JSON and names `pets.exe`, which I confirmed is the binary inside the Windows zip rather than assuming.

## Docs

All four READMEs, plus `RELEASING.md` — whose Platforms section claimed Windows users take an archive, and whose architecture note now covers both buckets.