### PR TITLE
Let a go install build know its own version

### DIFF
--- a/cmd/pets/collection.go
+++ b/cmd/pets/collection.go
@@ -27,7 +27,7 @@ func updateNotice(settings config.Config) string {
 	if err != nil {
 		return ""
 	}
-	latest := release.Check(config.StateDir(), version, settings.Update.Check, time.Now())
+	latest := release.Check(config.StateDir(), resolvedVersion(), settings.Update.Check, time.Now())
 	return render.UpdateNotice(latest, release.Command(executable))
 }
 

--- a/cmd/pets/main.go
+++ b/cmd/pets/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -25,6 +26,29 @@ import (
 )
 
 var version = "dev"
+
+// resolvedVersion prefers the ldflag a release build carries and falls back to the
+// module version the go tool records, so a `go install pkg@v0.2.9` build knows what it
+// is instead of calling itself dev and silently opting out of update checks.
+func resolvedVersion() string {
+	if version != "dev" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return version
+	}
+	return moduleVersion(info.Main.Version)
+}
+
+// moduleVersion normalises what ReadBuildInfo reports. A build from a working tree says
+// "(devel)", which is the same thing as dev.
+func moduleVersion(recorded string) string {
+	if recorded == "" || strings.HasPrefix(recorded, "(") {
+		return "dev"
+	}
+	return strings.TrimPrefix(recorded, "v")
+}
 
 const usage = `pets - a creature for every worktree
 
@@ -78,7 +102,7 @@ func dispatch(args []string) int {
 	case "install", "uninstall":
 		installCommand(args[0], args[1:])
 	case "version", "--version", "-v":
-		fmt.Println(version)
+		fmt.Println(resolvedVersion())
 	default:
 		fmt.Fprintf(os.Stderr, "pets: unknown command %q\n\n%s", args[0], usage)
 		return 1

--- a/cmd/pets/main_test.go
+++ b/cmd/pets/main_test.go
@@ -152,3 +152,18 @@ func TestVersionExitsZero(t *testing.T) {
 		}
 	}
 }
+
+// A `go install pkg@vX.Y.Z` build carries no ldflag, so without a fallback it calls
+// itself dev, and release.Newer deliberately ignores an unparseable version — meaning
+// source installs never hear about an upgrade.
+func TestModuleVersionNormalisesWhatTheGoToolRecords(t *testing.T) {
+	for recorded, want := range map[string]string{
+		"v0.2.9":  "0.2.9", // go install of a tag
+		"(devel)": "dev",   // built from a working tree
+		"":        "dev",   // no build info at all
+	} {
+		if got := moduleVersion(recorded); got != want {
+			t.Errorf("moduleVersion(%q) = %q, want %q", recorded, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up on a wart I noted during the rename audit rather than leaving it in the backlog.

Only goreleaser sets the version ldflag, so a binary built with `go install github.com/TevvvB/termagitchi/cmd/pets@v0.2.9` called itself `dev`. `release.Newer` deliberately ignores a version it cannot parse — correct for a working-tree build, wrong here, because it meant **source installs never heard about an upgrade at all**.

## The fallback has something real to read

Verified rather than assumed, with `go version -m` on an actually-installed binary:

```
path  github.com/TevvvB/termagitchi/cmd/pets
mod   github.com/TevvvB/termagitchi   v0.2.9
```

That `mod` line is what `debug.ReadBuildInfo().Main.Version` returns, so the fallback picks up `v0.2.9` and normalises it to `0.2.9`.

## Three cases

| Build | Reports |
|---|---|
| goreleaser release | ldflag, unchanged |
| `go install ...@v0.2.9` | `0.2.9` — new |
| `go build` in a working tree | `(devel)` → `dev`, unchanged |

The last row is why the update notice stays quiet locally, which was deliberate and still is.

## Test

The logic lives in a pure `moduleVersion(recorded string)` so it is testable without a real install; the test covers the tag, `(devel)` and the empty case. Note this cannot be end-to-end tested until it is in a tag — v0.2.9 predates the fix, so a `go install` of it still reports `dev`, correctly.